### PR TITLE
Show waiting screen after verifying on Relay first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Relay is a native macOS Matrix chat client built with SwiftUI. It wraps the Matrix Rust SDK (via UniFFI-generated Swift bindings) to provide a first-class Mac experience for the Matrix protocol.
+
+**Requirements:** macOS 26.0+ (Tahoe), Xcode 26.0+
+
+## Build & Run
+
+Open `Relay.xcodeproj` in Xcode. Dependencies resolve automatically via SPM.
+
+```bash
+# Build
+xcodebuild -scheme Relay -destination 'platform=macOS' build
+
+# Run tests
+xcodebuild -scheme Relay -destination 'platform=macOS' test
+```
+
+## Architecture
+
+Three-layer separation:
+
+- **Relay/** (App target) — SwiftUI views and preview view models. Entry point is `RelayApp.swift`, which injects `MatrixService` via SwiftUI environment. `ContentView` routes based on `AuthState` (logged out → login, logged in → main view). `MainView` is a two-pane layout: room list on the left, timeline on the right.
+
+- **RelaySDK/** (Framework target) — All Matrix SDK integration and business logic. `MatrixService` is the central `@Observable @MainActor` coordinator that owns sub-services:
+  - `AuthenticationService` — login (password + OAuth/OIDC), session restore
+  - `SyncManager` — sync lifecycle
+  - `RoomListManager` — reactive room list via SDK's `RoomListService`
+  - `RoomDetailViewModel` — timeline state and message sending
+  - `MediaService` — avatar/media caching
+  - `TimelineMessageMapper` — converts Rust SDK events to `TimelineMessage` models
+  - `KeychainService` — secure credential storage
+
+- **Packages/RelayCore/** (Local Swift package) — Shared protocols (`MatrixServiceProtocol`, `RoomDetailViewModelProtocol`) and model types (`TimelineMessage`, `RoomSummary`, etc.). This enables the app target to use preview/mock implementations without importing RelaySDK.
+
+## Key Dependencies (SPM)
+
+- `matrix-rust-components-swift` — Matrix Rust SDK UniFFI bindings
+- `swift-async-algorithms` — Async/await utilities
+- `SwiftSoup` — HTML parsing for formatted messages
+- `swift-collections` — Efficient data structures
+
+## Conventions
+
+- Commit messages: imperative mood, sentence-case (e.g. "Add thread support to timeline view")
+- Views bind directly to `@Observable` state; no Combine publishers
+- Protocol-driven design allows preview implementations in the app target without the real SDK

--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/SessionVerificationViewModelProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/SessionVerificationViewModelProtocol.swift
@@ -50,6 +50,8 @@ public enum VerificationState: Sendable {
     case sasStarted
     /// Emoji are ready for the user to compare and confirm.
     case showingEmojis
+    /// The user confirmed the emoji match; waiting for the SDK to finish.
+    case approving
     /// The user confirmed the emoji match and verification succeeded.
     case verified
     /// Either side cancelled the verification.

--- a/Relay/Views/SettingsView.swift
+++ b/Relay/Views/SettingsView.swift
@@ -511,7 +511,7 @@ private struct VerificationSheet: View {
             switch viewModel.state {
             case .idle:
                 idleView
-            case .requesting, .waitingForOtherDevice, .sasStarted:
+            case .requesting, .waitingForOtherDevice, .sasStarted, .approving:
                 waitingView
             case .showingEmojis:
                 emojiView

--- a/RelayKit/Services/SessionVerificationViewModel.swift
+++ b/RelayKit/Services/SessionVerificationViewModel.swift
@@ -79,6 +79,7 @@ public final class SessionVerificationViewModel: SessionVerificationViewModelPro
     /// Confirms that the displayed emoji match on both devices, completing verification.
     @MainActor
     public func approveVerification() async {
+        state = .approving
         do {
             try await controller.approveVerification()
             logger.info("Verification approved")


### PR DESCRIPTION
Fixes #13 by showing the previous waiting for device page if a user presses `they match` on Relay first. 

Prior behaviour has the UI give no indication the button was successfully pressed. 

This PR also adds a CLAUDE.md for agent guidance, can be dropped if not desired. 