### PR TITLE
Change preview of rooms to only visualize links

### DIFF
--- a/Relay/Views/RoomListRow.swift
+++ b/Relay/Views/RoomListRow.swift
@@ -58,7 +58,7 @@ struct RoomListRow: View {
                 }
 
                 if let msg = room.lastMessage {
-                    Text(msg)
+                    Text(msg.visualizeLinksOnly())
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -91,6 +91,30 @@ extension RoomListRow {
         } else {
             return date.formatted(.dateTime.month(.abbreviated).day())
         }
+    }
+}
+
+// MARK: - AttributedString Extension
+
+extension AttributedString {
+    /// Returns a copy of the attributed string where links are stripped of their
+    /// interaction but keep their accent color.
+    func visualizeLinksOnly() -> AttributedString {
+        var result = self
+        var linkRanges: [Range<AttributedString.Index>] = []
+        
+        for run in result.runs {
+            if run.attributes.link != nil {
+                linkRanges.append(run.range)
+            }
+        }
+        
+        for range in linkRanges {
+            result[range].link = nil
+            result[range].foregroundColor = .accentColor
+        }
+        
+        return result
     }
 }
 


### PR DESCRIPTION
Remove the default action of opening the urls by removing the link attribute, but keeps the distinction of a URL by having the link in the accent color.

Closes #42 