### PR TITLE
Add preview of author of the last message in room list and notifications

### DIFF
--- a/Packages/RelayInterface/Sources/RelayInterface/Models/RoomSummary.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Models/RoomSummary.swift
@@ -37,6 +37,9 @@ public final class RoomSummary: Identifiable {
     /// The `mxc://` URL of the room's avatar image, if set.
     public var avatarURL: String?
 
+    /// The room's most recent author, if available
+    public var lastAuthor: String?
+    
     /// A rich text preview of the most recent message in the room.
     ///
     /// The attributed string preserves inline Markdown formatting (bold, italic, code,
@@ -97,6 +100,7 @@ public final class RoomSummary: Identifiable {
         name: String,
         topic: String? = nil,
         avatarURL: String? = nil,
+        lastAuthor: String? = nil,
         lastMessage: AttributedString? = nil,
         lastMessageTimestamp: Date? = nil,
         unreadCount: UInt = 0,
@@ -110,6 +114,7 @@ public final class RoomSummary: Identifiable {
         self.name = name
         self.topic = topic
         self.avatarURL = avatarURL
+        self.lastAuthor = lastAuthor
         self.lastMessage = lastMessage
         self.lastMessageTimestamp = lastMessageTimestamp
         self.unreadMessages = unreadCount

--- a/Relay/RelayApp.swift
+++ b/Relay/RelayApp.swift
@@ -154,7 +154,13 @@ struct RelayApp: App {
         if NSApp.isActive, selectedRoomId == event.roomId { return }
 
         let content = UNMutableNotificationContent()
-        content.title = event.roomName
+        
+        if (event.isDirect) {
+            content.title = event.roomName
+        } else {
+            content.title = "\(event.messageAuthor ?? "Unknown sender") in \(event.roomName)"
+        }
+        
         content.body = event.messageBody ?? "New message"
         content.sound = .default
         content.threadIdentifier = event.roomId

--- a/Relay/Services/PreviewMatrixService.swift
+++ b/Relay/Services/PreviewMatrixService.swift
@@ -237,6 +237,7 @@ final class PreviewMatrixService: MatrixServiceProtocol {
             name: "Design Team",
             topic: "UI/UX design discussion",
             avatarURL: nil,
+            lastAuthor: "Alice",
             lastMessage: try? AttributedString(
                 markdown: "Let's **finalize** the mockups tomorrow",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -251,6 +252,7 @@ final class PreviewMatrixService: MatrixServiceProtocol {
             id: "!alice:matrix.org",
             name: "Alice",
             avatarURL: nil,
+            lastAuthor: "Alice",
             lastMessage: try? AttributedString(
                 markdown: "Sounds good, talk *soon*!",
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -264,6 +266,7 @@ final class PreviewMatrixService: MatrixServiceProtocol {
             name: "Matrix HQ",
             topic: "General discussion on anything related to Matrix",
             avatarURL: nil,
+            lastAuthor: nil,
             lastMessage: nil,
             lastMessageTimestamp: nil,
             unreadCount: 0,
@@ -274,6 +277,7 @@ final class PreviewMatrixService: MatrixServiceProtocol {
             id: "!bob:matrix.org",
             name: "Bob Chen",
             avatarURL: nil,
+            lastAuthor: "Charlie",
             lastMessage: AttributedString("Sent an image"),
             lastMessageTimestamp: .now.addingTimeInterval(-86400 * 2),
             unreadCount: 12,

--- a/Relay/Views/RoomListRow.swift
+++ b/Relay/Views/RoomListRow.swift
@@ -86,7 +86,8 @@ struct RoomListRow: View {
                 }
 
                 if let msg = room.lastMessage {
-                    Text(msg.visualizeLinksOnly())
+                    let author = RoomListRow.formatAuthor(room.lastAuthor)
+                    Text(author + msg.visualizeLinksOnly())
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -120,6 +121,16 @@ extension RoomListRow {
             return date.formatted(.dateTime.month(.abbreviated).day())
         }
     }
+    
+    /// Formats an author for preview in the roomlist, always adds a ": " at the end of the name, for easier concatination with the message
+    static func formatAuthor(_ author: String?) -> AttributedString {
+        let authorName = author ?? "Unknown Sender"
+        if let markdown = try? AttributedString(markdown: "**\(authorName)**: ",
+                        options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+            return markdown
+        }
+        return AttributedString("\(authorName): ")
+    }
 }
 
 // MARK: - AttributedString Extension
@@ -152,6 +163,7 @@ extension AttributedString {
     RoomListRow(room: RoomSummary(
         id: "!design:matrix.org",
         name: "Design Team",
+        lastAuthor: "Alice",
         lastMessage: AttributedString("Let's finalize the mockups tomorrow"),
         lastMessageTimestamp: .now.addingTimeInterval(-300),
         unreadCount: 3,
@@ -164,6 +176,7 @@ extension AttributedString {
     RoomListRow(room: RoomSummary(
         id: "!hq:matrix.org",
         name: "Matrix HQ",
+        lastAuthor: "Bob",
         lastMessage: AttributedString("General discussion"),
         lastMessageTimestamp: .now.addingTimeInterval(-7200),
         unreadCount: 42,
@@ -176,6 +189,7 @@ extension AttributedString {
     RoomListRow(room: RoomSummary(
         id: "!dev:matrix.org",
         name: "Development",
+        lastAuthor: "Alice",
         lastMessage: AttributedString("Merged the refactor PR"),
         lastMessageTimestamp: .now.addingTimeInterval(-600),
         unreadCount: 5,
@@ -188,6 +202,7 @@ extension AttributedString {
     RoomListRow(room: RoomSummary(
         id: "!alice:matrix.org",
         name: "Alice",
+        lastAuthor: "Alice",
         lastMessage: AttributedString("Sounds good, talk soon!"),
         lastMessageTimestamp: .now.addingTimeInterval(-7200),
         isDirect: true

--- a/RelayKit/Services/RoomListManager.swift
+++ b/RelayKit/Services/RoomListManager.swift
@@ -24,10 +24,14 @@ public struct RoomNotificationEvent: Sendable {
     public let roomId: String
     /// The display name of the room.
     public let roomName: String
+    /// A plain-text representation of the latest author, if available.
+    public let messageAuthor: String?
     /// A plain-text preview of the latest message, if available.
     public let messageBody: String?
     /// Whether the new activity includes a mention of the current user.
     public let isMention: Bool
+    /// Whether the new activity is in a direct message room.
+    public let isDirect: Bool
 }
 
 /// Maintains the sorted list of joined rooms using the SDK's reactive `RoomListService`.
@@ -351,14 +355,18 @@ private final class RoomEntry: Identifiable {
                 let roomName = summary.name
                 let roomId = id
                 let isMention = hadNewMentions
+                let isDirect = summary.isDirect
                 Task { [weak self] in
                     guard let self else { return }
                     let body = await self.latestMessageBody()
+                    let author = await self.latestMessageAuthor()
                     self.onNotificationEvent?(RoomNotificationEvent(
                         roomId: roomId,
                         roomName: roomName,
+                        messageAuthor: author,
                         messageBody: body,
-                        isMention: isMention
+                        isMention: isMention,
+                        isDirect: isDirect
                     ))
                 }
             }
@@ -372,6 +380,7 @@ private final class RoomEntry: Identifiable {
             guard let self else { return }
             // swiftlint:disable:next identifier_name
             let (msg, ts) = await self.latestMessagePreview()
+            self.summary.lastAuthor = await self.latestMessageAuthor()
             self.summary.lastMessage = msg
             self.summary.lastMessageTimestamp = ts
             self.onInfoUpdated?()
@@ -404,6 +413,31 @@ private final class RoomEntry: Identifiable {
             }
         }
         return nil
+    }
+    
+    /// Returns a plain-text representation latest author for notification content.
+    private func latestMessageAuthor() async -> String? {
+        let latest = await room.latestEvent()
+        let sender: String?
+        let profile: ProfileDetails
+        
+        switch latest {
+        case .remote(_, let s, _, let p, _):
+            sender = s
+            profile = p
+        case .local(_, let s, let p, _, _):
+            sender = s
+            profile = p
+        case .remoteInvite(_, let s, let p):
+            sender = s
+            profile = p
+        case .none: return nil
+        }
+        
+        switch (profile) {
+        case .ready(let displayName, _, _): return displayName ?? sender
+        default: return sender
+        }
     }
 
     // swiftlint:disable identifier_name


### PR DESCRIPTION
Adds a preview of the author in the RoomListView:

<img width="324" height="158" alt="image" src="https://github.com/user-attachments/assets/60d6911f-4fc3-44f5-8dce-3e4abba9164e" />

as well as an author to the front of the message if the room isn't a direct room:
<img width="352" height="62" alt="image" src="https://github.com/user-attachments/assets/a379def5-10b4-4412-bbd1-83c7c5f735a2" />
