### PR TITLE
Network state awareness: don't bounce to login when offline and distingush between Network Offline and Server Unavailable

### DIFF
--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/MatrixServiceProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/MatrixServiceProtocol.swift
@@ -156,6 +156,15 @@ public protocol MatrixServiceProtocol: AnyObject, Observable {
     /// "rooms loaded but the list is empty."
     var hasLoadedRooms: Bool { get }
 
+    /// Whether the device currently has any viable network path
+    /// (Wi-Fi, ethernet, or cellular). Reflects `NWPathMonitor` state.
+    ///
+    /// Used together with ``syncState`` to disambiguate the offline
+    /// banner: `.offline` + `isNetworkConnected == false` means the
+    /// radio is off; `.offline` + `isNetworkConnected == true` means
+    /// the homeserver itself is unreachable.
+    var isNetworkConnected: Bool { get }
+
     /// Attempts to restore a previously saved session from the keychain.
     func restoreSession() async
 
@@ -738,6 +747,7 @@ private final class PlaceholderMatrixService: MatrixServiceProtocol {
     var spaces: [RoomSummary] = []
     var isSyncing: Bool { false }
     var hasLoadedRooms: Bool = false
+    var isNetworkConnected: Bool = true
     var isSessionVerified: Bool = false
     var hasCheckedVerificationState: Bool = false
     var pendingVerificationRequest: IncomingVerificationRequest?

--- a/Relay/Services/PreviewMatrixService.swift
+++ b/Relay/Services/PreviewMatrixService.swift
@@ -28,6 +28,7 @@ final class PreviewMatrixService: MatrixServiceProtocol {
     var spaces: [RoomSummary] = PreviewMatrixService.sampleSpaces
     var isSyncing: Bool { false }
     var hasLoadedRooms: Bool = true
+    var isNetworkConnected: Bool = true
     var isSessionVerified: Bool = true
     var hasCheckedVerificationState: Bool = true
     var pendingVerificationRequest: IncomingVerificationRequest?

--- a/Relay/Views/Banners/OfflineBanner.swift
+++ b/Relay/Views/Banners/OfflineBanner.swift
@@ -32,6 +32,43 @@ struct OfflineBanner: View {
         bannerWidth < Self.compactThreshold
     }
 
+    /// When the radio is off (`NWPathMonitor` reports no path) we say
+    /// "Network Offline" and use the wifi-slash glyph. When the radio
+    /// is up but the homeserver isn't responding we say "Server
+    /// Offline" with a server-shaped glyph. Both share the same banner
+    /// chrome and the same orange tint — only the copy/icon differs.
+    private var isNetworkOffline: Bool {
+        !matrixService.isNetworkConnected
+    }
+
+    private var titleText: String {
+        isNetworkOffline ? "Network Offline" : "Server Unreachable"
+    }
+
+    /// Status icon. For "Network Offline" we use the standard
+    /// `wifi.slash` SF Symbol. For "Server Offline" SF Symbols doesn't
+    /// ship a slashed-server glyph, so we pair `xserve` with a
+    /// caution-triangle badge — same pattern as
+    /// ``foo.badge.exclamationmark`` symbols Apple uses elsewhere.
+    @ViewBuilder
+    private func statusIcon(size: CGFloat) -> some View {
+        if isNetworkOffline {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: size))
+                .foregroundStyle(.secondary)
+        } else {
+            Image(systemName: "xserve")
+                .font(.system(size: size))
+                .foregroundStyle(.secondary)
+                .overlay(alignment: .bottomTrailing) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: size * 0.55))
+                        .foregroundStyle(.orange)
+                        .offset(x: size * 0.22, y: size * 0.18)
+                }
+        }
+    }
+
     var body: some View {
         if matrixService.syncState == .offline {
             Group {
@@ -64,12 +101,10 @@ struct OfflineBanner: View {
 
     private var regularContent: some View {
         HStack(spacing: 8) {
-            Image(systemName: "wifi.slash")
-                .foregroundStyle(.secondary)
-                .font(.body)
+            statusIcon(size: 17)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text("Offline")
+                Text(titleText)
                     .font(.subheadline)
                     .fontWeight(.semibold)
             }
@@ -80,11 +115,9 @@ struct OfflineBanner: View {
 
     private var compactContent: some View {
         VStack(spacing: 6) {
-            Image(systemName: "wifi.slash")
-                .foregroundStyle(.secondary)
-                .font(.system(size: 24))
+            statusIcon(size: 24)
 
-            Text("Offline")
+            Text(titleText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -93,7 +126,7 @@ struct OfflineBanner: View {
 
 // MARK: - Previews
 
-#Preview("Offline") {
+#Preview("Network Offline") {
     VStack {
         Spacer()
         OfflineBanner()
@@ -101,12 +134,13 @@ struct OfflineBanner: View {
     .environment(\.matrixService, {
         let service = PreviewMatrixService()
         service.syncState = .offline
+        service.isNetworkConnected = false
         return service
     }())
     .frame(width: 280, height: 200)
 }
 
-#Preview("Offline (Compact)") {
+#Preview("Server Unreachable") {
     VStack {
         Spacer()
         OfflineBanner()
@@ -114,6 +148,21 @@ struct OfflineBanner: View {
     .environment(\.matrixService, {
         let service = PreviewMatrixService()
         service.syncState = .offline
+        service.isNetworkConnected = true
+        return service
+    }())
+    .frame(width: 280, height: 200)
+}
+
+#Preview("Network Offline (Compact)") {
+    VStack {
+        Spacer()
+        OfflineBanner()
+    }
+    .environment(\.matrixService, {
+        let service = PreviewMatrixService()
+        service.syncState = .offline
+        service.isNetworkConnected = false
         return service
     }())
     .frame(width: 116, height: 200)

--- a/RelayKit/Services/AuthenticationService.swift
+++ b/RelayKit/Services/AuthenticationService.swift
@@ -34,6 +34,28 @@ nonisolated struct StoredSession: Codable, Sendable {
     var oidcData: String?
 }
 
+/// Outcome of an attempt to restore a previously saved session.
+///
+/// Distinguishes "no keychain session at all" (→ login screen) from
+/// "session exists but we couldn't reach the homeserver" (→ restore
+/// the user into a cache-only experience and retry once connectivity
+/// returns).
+enum RestoreOutcome {
+    /// No saved session in the keychain. Caller should show login.
+    case noSavedSession
+    /// Session restored successfully and is ready for sync.
+    case restored(ClientProxy, userId: String)
+    /// A session is saved but the homeserver couldn't be reached
+    /// (no network, well-known discovery failed, connection timed out).
+    /// Caller should treat the user as logged-in but with sync stuck
+    /// offline, and retry the full restore when connectivity returns.
+    case offlineWithSavedSession(userId: String, homeserverUrl: String)
+    /// A session is saved but restore failed for a non-network reason
+    /// (auth invalidated, schema mismatch, etc.). Caller should show
+    /// an error.
+    case failed(Error)
+}
+
 /// Handles Matrix authentication: password login, OAuth/OIDC, session restore, and logout.
 ///
 /// ``AuthenticationService`` encapsulates all authentication-related logic, including
@@ -47,6 +69,12 @@ nonisolated struct StoredSession: Codable, Sendable {
 /// the service to AppKit or AuthenticationServices.
 @MainActor
 final class AuthenticationService {
+
+    private let networkMonitor: NetworkMonitor
+
+    init(networkMonitor: NetworkMonitor) {
+        self.networkMonitor = networkMonitor
+    }
 
     // MARK: - Data Paths
 
@@ -117,13 +145,26 @@ final class AuthenticationService {
 
     /// Attempts to restore a previously saved session from the keychain.
     ///
-    /// - Returns: A tuple of the authenticated ``ClientProxy`` and user ID, or `nil` if no
-    ///   valid session was found.
-    func restoreSession() async -> (ClientProxy, String)? {
+    /// Distinguishes "no saved session" from "homeserver couldn't be
+    /// reached" so the caller (``MatrixService``) can choose between
+    /// going to the login screen and entering an offline-restored
+    /// cache-only state. See ``RestoreOutcome``.
+    func restoreSession() async -> RestoreOutcome {
         guard let data = KeychainService.load(),
               let stored = try? JSONDecoder().decode(StoredSession.self, from: data)
         else {
-            return nil
+            return .noSavedSession
+        }
+
+        // If the radio is off, don't even try `buildClient()` — well-known
+        // discovery would just fail. Skip straight to offline-restore so
+        // the user sees their cached data instead of the login screen.
+        guard networkMonitor.isConnected else {
+            logger.info("Restoring session offline (network monitor reports disconnected) for \(stored.userId)")
+            return .offlineWithSavedSession(
+                userId: stored.userId,
+                homeserverUrl: stored.homeserverUrl
+            )
         }
 
         do {
@@ -148,10 +189,17 @@ final class AuthenticationService {
 
             logger.debug("Session restored successfully for \(stored.userId)")
             let clientProxy = try ClientProxy(client: client)
-            return (clientProxy, stored.userId)
+            return .restored(clientProxy, userId: stored.userId)
         } catch {
+            if NetworkErrorClassifier.isOfflineShaped(error) {
+                logger.info("Session restore deferred — homeserver unreachable: \(error.localizedDescription)")
+                return .offlineWithSavedSession(
+                    userId: stored.userId,
+                    homeserverUrl: stored.homeserverUrl
+                )
+            }
             logger.error("Session restore failed: \(error)")
-            return nil
+            return .failed(error)
         }
     }
 

--- a/RelayKit/Services/MatrixService.swift
+++ b/RelayKit/Services/MatrixService.swift
@@ -42,6 +42,7 @@ public final class MatrixService: MatrixServiceProtocol {
 
     public var isSyncing: Bool { syncState == .syncing || syncState == .running }
     public var hasLoadedRooms: Bool { roomListManager.hasLoadedRooms }
+    public var isNetworkConnected: Bool { networkMonitor.isConnected }
 
     public private(set) var isSessionVerified: Bool = false
     public private(set) var hasCheckedVerificationState: Bool = false
@@ -77,8 +78,8 @@ public final class MatrixService: MatrixServiceProtocol {
 
     // MARK: - Sub-Services
 
-    private let auth = AuthenticationService()
     private let networkMonitor = NetworkMonitor()
+    private let auth: AuthenticationService
     private let syncManager: SyncManager
     private let roomListManager = RoomListManager()
     private let spaceListManager = SpaceListManager()
@@ -88,17 +89,69 @@ public final class MatrixService: MatrixServiceProtocol {
     /// Creates a new ``MatrixService``. Call ``restoreSession()`` after initialization to
     /// attempt automatic sign-in from a previously saved keychain session.
     public init() {
+        auth = AuthenticationService(networkMonitor: networkMonitor)
         syncManager = SyncManager(networkMonitor: networkMonitor)
     }
 
     // MARK: - Session Restore
 
     public func restoreSession() async {
-        if let (restoredClient, userId) = await auth.restoreSession() {
+        // Start the network monitor early so `AuthenticationService` can
+        // see the current connectivity state and so the SyncManager can
+        // wake us up when the network returns after an offline restore.
+        networkMonitor.start()
+
+        switch await auth.restoreSession() {
+        case .noSavedSession:
+            authState = .loggedOut
+
+        case .restored(let restoredClient, let userId):
             client = restoredClient
             await restoredClient.loadProfile()
             authState = .loggedIn(userId: userId)
-        } else {
+
+        case .offlineWithSavedSession(let userId, _):
+            // We have a saved session but couldn't reach the homeserver.
+            // Treat the user as logged-in so they see their cached rooms,
+            // and ask SyncManager to retry the full restore once
+            // connectivity comes back.
+            authState = .loggedIn(userId: userId)
+            syncManager.onPendingOnlineRestore = { [weak self] in
+                await self?.retryPendingOnlineRestore()
+            }
+            syncManager.enterPendingOnlineRestore()
+
+        case .failed(let error):
+            authState = .error(error.localizedDescription)
+        }
+    }
+
+    /// Called by ``SyncManager`` when it detects a network reconnect while
+    /// we're still in the offline-restored state. Re-runs
+    /// ``AuthenticationService/restoreSession()`` and, on success, hands
+    /// the freshly built ``ClientProxy`` to the sync pipeline.
+    private func retryPendingOnlineRestore() async {
+        switch await auth.restoreSession() {
+        case .restored(let restoredClient, let userId):
+            client = restoredClient
+            await restoredClient.loadProfile()
+            authState = .loggedIn(userId: userId)
+            // Tear down the placeholder pending-restore handler before
+            // performSync wires up the real onSyncServiceRestarted hook.
+            syncManager.onPendingOnlineRestore = nil
+            await performSync()
+
+        case .offlineWithSavedSession:
+            // Still can't reach the homeserver — stay offline. The
+            // network monitor will fire again when connectivity flips,
+            // and SyncManager will call us back.
+            break
+
+        case .failed(let error):
+            authState = .error(error.localizedDescription)
+
+        case .noSavedSession:
+            // Keychain went away under us mid-restore. Bounce to login.
             authState = .loggedOut
         }
     }

--- a/RelayKit/Services/NetworkErrorClassifier.swift
+++ b/RelayKit/Services/NetworkErrorClassifier.swift
@@ -1,0 +1,53 @@
+// Copyright 2026 Link Dupont
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MatrixRustSDK
+
+/// Classifies SDK errors as transient connectivity / homeserver-reachability
+/// problems vs. permanent failures (auth invalidated, schema mismatch, …).
+///
+/// We pattern-match the SDK's typed error enums (`ClientBuildError`,
+/// `ClientError.MatrixApi`) directly — no string sniffing. The classifier
+/// deliberately does **not** flag `unknownToken` / `unauthorized`: those
+/// need a re-auth flow and shouldn't be silently masked behind an
+/// "Offline" pill.
+enum NetworkErrorClassifier {
+    /// True when an SDK error looks like a transient connectivity /
+    /// homeserver-reachability problem. From the user's perspective both
+    /// "Wi-Fi off" and "homeserver down" feel the same — both produce the
+    /// same offline UX (banner + cached data + auto-retry).
+    static func isOfflineShaped(_ error: Error) -> Bool {
+        if let build = error as? ClientBuildError {
+            switch build {
+            case .ServerUnreachable, .WellKnownLookupFailed:
+                return true
+            default:
+                return false
+            }
+        }
+
+        if let client = error as? ClientError,
+           case .MatrixApi(let kind, _, _, _) = client {
+            switch kind {
+            case .connectionFailed, .connectionTimeout:
+                return true
+            default:
+                return false
+            }
+        }
+
+        return false
+    }
+}

--- a/RelayKit/Services/SyncManager.swift
+++ b/RelayKit/Services/SyncManager.swift
@@ -52,16 +52,42 @@ final class SyncManager {
     /// sync service without tearing down existing room state.
     var onSyncServiceRestarted: ((SyncService) async throws -> Void)?
 
+    /// Called when a saved session was restored offline and connectivity has
+    /// returned. ``MatrixService`` sets this to retry the full
+    /// `restoreSession` + `startSync` pipeline. Until that succeeds the
+    /// app stays in an "Offline" state, but the user is treated as
+    /// logged-in with cached data.
+    var onPendingOnlineRestore: (() async -> Void)?
+
     private let networkMonitor: NetworkMonitor
 
     private var client: (any ClientProxyProtocol)?
     private var syncStateHandle: TaskHandle?
     private var stateObservationTask: Task<Void, Never>?
     private var networkObservationTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
 
     /// Whether the sync service has completed its initial startup.
     /// Used to distinguish the first `startSync` call from network-triggered restarts.
     private var hasCompletedInitialSync = false
+
+    /// True between ``enterPendingOnlineRestore()`` and the first successful
+    /// `startSync`. While true, the network observer treats reconnects as
+    /// "retry the deferred restore" rather than "rebuild the sync service".
+    private var isPendingOnlineRestore = false
+
+    // MARK: - Reconnect backoff (truncated binary exponential)
+    //
+    // Same shape as Ethernet CSMA/CD's collision backoff: after the *n*th
+    // consecutive failure, sleep a uniformly random number of slots in
+    // [0, 2^n − 1] before retrying. `maxBackoffExponent` caps the window so
+    // the wait saturates instead of growing without bound. A successful
+    // sync resets `reconnectAttempt` to 0. Randomization avoids a
+    // thundering herd of clients all retrying in lockstep after a shared
+    // outage.
+    private var reconnectAttempt: Int = 0
+    private let baseSlotSeconds: Double = 1
+    private let maxBackoffExponent: Int = 6
 
     init(networkMonitor: NetworkMonitor) {
         self.networkMonitor = networkMonitor
@@ -77,7 +103,7 @@ final class SyncManager {
     /// - Parameter client: The authenticated client proxy.
     /// - Throws: If sync fails to start or is cancelled.
     func startSync(client: any ClientProxyProtocol) async throws {
-        guard syncState == .idle else { return }
+        guard syncState == .idle || isPendingOnlineRestore else { return }
 
         self.client = client
         syncState = .syncing
@@ -88,8 +114,26 @@ final class SyncManager {
         // Wait for the first .running state (up to 15 seconds)
         await waitForFirstSync()
         hasCompletedInitialSync = true
+        isPendingOnlineRestore = false
+        reconnectAttempt = 0
 
         // Begin observing network changes for offline/online transitions
+        startNetworkObservation()
+    }
+
+    /// Marks the sync layer as "logged in but not yet able to talk to the
+    /// homeserver" — used when ``AuthenticationService`` returned
+    /// `.offlineWithSavedSession`. Sets ``syncState`` to `.offline`,
+    /// triggering the existing offline banner, and starts watching
+    /// ``NetworkMonitor`` so we can retry the full
+    /// `restoreSession` + `startSync` pipeline once connectivity returns.
+    func enterPendingOnlineRestore() {
+        isPendingOnlineRestore = true
+        syncState = .offline
+        // Start the network monitor so we get a callback when connectivity
+        // comes back. Safe to call repeatedly — it no-ops if already
+        // running.
+        networkMonitor.start()
         startNetworkObservation()
     }
 
@@ -101,6 +145,8 @@ final class SyncManager {
         networkObservationTask = nil
         stateObservationTask?.cancel()
         stateObservationTask = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
         syncStateHandle = nil
 
         if let syncService {
@@ -109,7 +155,10 @@ final class SyncManager {
         syncService = nil
         client = nil
         hasCompletedInitialSync = false
+        isPendingOnlineRestore = false
+        reconnectAttempt = 0
         onSyncServiceRestarted = nil
+        onPendingOnlineRestore = nil
         syncState = .idle
     }
 
@@ -166,7 +215,14 @@ final class SyncManager {
                 case .terminated:
                     self.syncState = .error("The sync service was terminated.")
                 case .error:
-                    self.syncState = .error("The sync service encountered an error.")
+                    // The SDK doesn't expose a typed underlying error here
+                    // (the listener only delivers the variant). Treat it
+                    // as offline-shaped: drop to `.offline` and schedule a
+                    // backoff retry. If it really is a terminal error,
+                    // every retry will hit the same wall but the user
+                    // sees a banner instead of a hard-stuck sync.
+                    self.syncState = .offline
+                    self.scheduleReconnect()
                 }
             }
         }
@@ -195,6 +251,11 @@ final class SyncManager {
 
                 if !isConnected {
                     await self.handleOffline()
+                } else if self.isPendingOnlineRestore {
+                    // We have a saved session but never managed to build a
+                    // client. Ask MatrixService to retry the full restore.
+                    logger.info("Network restored — retrying deferred session restore")
+                    await self.onPendingOnlineRestore?()
                 } else if self.syncState == .offline {
                     await self.handleOnline()
                 }
@@ -209,6 +270,11 @@ final class SyncManager {
     /// messages while there is no network path. Queued messages remain in the
     /// local store and are flushed when ``handleOnline()`` re-enables them.
     private func handleOffline() async {
+        // Cancel any pending reconnect — the network observer is now
+        // authoritative for when we come back online.
+        reconnectTask?.cancel()
+        reconnectTask = nil
+
         guard syncState == .running || syncState == .syncing else { return }
 
         logger.info("Network lost — stopping sync service")
@@ -259,8 +325,34 @@ final class SyncManager {
         } catch is CancellationError {
             // Shutdown in progress — don't overwrite state
         } catch {
-            logger.error("Failed to restart sync after connectivity restored: \(error)")
-            syncState = .error("Failed to restart sync: \(error.localizedDescription)")
+            if NetworkErrorClassifier.isOfflineShaped(error) {
+                logger.info("Reconnect attempt failed (homeserver still unreachable): \(error.localizedDescription)")
+                syncState = .offline
+                scheduleReconnect()
+            } else {
+                logger.error("Failed to restart sync after connectivity restored: \(error)")
+                syncState = .error("Failed to restart sync: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Schedules a retry of ``handleOnline()`` using truncated binary
+    /// exponential backoff. Picks a random delay in
+    /// `[0, 2^n − 1] × baseSlotSeconds` where `n = min(reconnectAttempt,
+    /// maxBackoffExponent)`. A fresh `NetworkMonitor` offline event
+    /// supersedes the pending retry via ``handleOffline()``.
+    private func scheduleReconnect() {
+        reconnectTask?.cancel()
+        let attempt = min(reconnectAttempt, maxBackoffExponent)
+        let upperBound = max(1, 1 << attempt) // at attempt=0 → 1 slot
+        let slots = Int.random(in: 0..<upperBound)
+        let delay = Double(slots) * baseSlotSeconds
+        reconnectAttempt += 1
+        logger.info("Scheduling sync reconnect attempt #\(self.reconnectAttempt) in \(delay)s")
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self, !Task.isCancelled else { return }
+            await self.handleOnline()
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses subpop/Relay#87
Cold-launching with no connectivity used to bounce to the login screen because `AuthenticationService.restoreSession()` returned `nil` for both "no saved session" and "buildClient failed." This branch distinguishes the two and surfaces an offline state in the sidebar instead.
- New `RestoreOutcome` enum on `AuthenticationService`: `.noSavedSession` / `.restored` / `.offlineWithSavedSession` / `.failed`.
- When a saved session exists but the homeserver is unreachable, we keep the user logged in, flip `syncState` to `.offline`, and ask `SyncManager` to retry the full restore on the next reconnect.
- Network-shaped SDK errors are classified by typed pattern-match in `NetworkErrorClassifier` — `ClientBuildError.{ServerUnreachable, WellKnownLookupFailed}` and `ClientError.MatrixApi(.connectionFailed / .connectionTimeout)`. No string sniffing.
- Runtime sync failures of those shapes drop to `.offline` instead of the terminal `.error` state and retry with truncated binary exponential backoff (Ethernet-style, base 1 s, cap 2⁶ slots, randomized to avoid thundering-herd reconnects).
- Bottom-of-sidebar pill disambiguates the two cases:
  - **Network Offline** with `wifi.slash` glyph when `NWPathMonitor` reports no path.
  - **Server Unreachable** with an `xserve` glyph + caution-triangle badge when the radio is up but the homeserver isn't responding.
## Out of scope
This commit fixes the login-bounce regression but **doesn't yet populate the timeline with cached messages during an offline cold-start** — that requires the SDK client itself to build successfully without contacting the homeserver, which is its own investigation. For now the offline-restored state shows MainView with empty rooms until connectivity returns.
## Test plan
- [ ] Sign in normally with the network up, then airplane-mode and relaunch — app stays logged in, sidebar shows "Network Offline" pill (wifi-slash glyph).
- [ ] Sign in normally, then disable just the homeserver (e.g. block its hostname, point it at a dead IP) and relaunch — sidebar shows "Server Unreachable" pill (server + caution glyph).
- [ ] Restore connectivity in either case — sync resumes within the backoff window, pill disappears.
- [ ] First-time launch with no saved session and no network still shows the login screen.
- [ ] No saved session + network present: login flow unchanged.
- [ ] Mid-session network drop: existing offline behavior unchanged (sync stops, queue disabled, banner appears).
🤖 Generated with [Claude Code](https://claude.com/claude-code)