### PR TITLE
Fix in-progress call join, failed-connect teardown, and a Swift 6 build error

### DIFF
--- a/Relay/Views/MainView.swift
+++ b/Relay/Views/MainView.swift
@@ -468,10 +468,17 @@ struct MainView: View { // swiftlint:disable:this type_body_length
             do {
                 let creds = try await matrixService.callCredentials(for: roomId)
                 try await viewModel.connect(url: creds.livekitURL, token: creds.token, sfuServiceURL: creds.sfuServiceURL)
+                callManager.isPreparingCredentials = false
             } catch {
+                // Surface the failure and fully tear down the call so the
+                // toolbar call button (disabled while `hasActiveCall`) is
+                // re-enabled. Without this the failed view model stays set
+                // and the button is stuck disabled until the app restarts —
+                // the `.failed` overlay's Dismiss is the only other path and
+                // its window is easily missed behind the main window.
                 errorReporter.report(.callFailed(error.localizedDescription))
+                await callManager.endCall()
             }
-            callManager.isPreparingCredentials = false
         }
     }
 

--- a/RelayKit/Call/CallViewModel.swift
+++ b/RelayKit/Call/CallViewModel.swift
@@ -475,9 +475,30 @@ public final class CallViewModel: CallViewModelProtocol {
             state = .connected
             connectingPhase = nil
             videoTrackRevision += 1
+
+            // Enumerate participants already in the room. LiveKit's
+            // `participantDidConnect` only fires for peers who join AFTER
+            // us; when we join an in-progress call the existing peers are
+            // already in `room.remoteParticipants`, so without this sync
+            // the UI would sit on "waiting for participants" and never show
+            // them. (When we're the first to join this is a no-op and
+            // later joiners arrive via the delegate.)
+            syncParticipants(trackChanged: true)
+            // Existing peers won't fire `participantDidConnect`, so push our
+            // key to them explicitly — mirrors the redistribute we'd
+            // otherwise do on their join.
+            if isE2eeEnabled {
+                for participant in room.remoteParticipants.values {
+                    if let identity = participant.identity?.stringValue {
+                        redistributeKey(to: identity)
+                    }
+                }
+            }
+
             activityLog?.log(
                 category: .call, severity: .info, source: "CallViewModel",
                 summary: "Connected to call",
+                detail: "Existing remote participants: \(room.remoteParticipants.count).",
                 roomId: roomID
             )
         } catch {

--- a/RelayKit/Call/CallWidgetBridge.swift
+++ b/RelayKit/Call/CallWidgetBridge.swift
@@ -750,11 +750,15 @@ public final class CallWidgetBridge: @unchecked Sendable {
             }
             let identitiesJoined = participantIdentities.joined(separator: ", ")
             let fp = SHA256.hash(data: keyData).prefix(8).map { String(format: "%02x", $0) }.joined()
-            let failureNote = setFailures.isEmpty ? "" : " setRawKey failures: \(setFailures.joined(separator: "; "))."
+            // Snapshot the mutable accumulator into immutable lets before the
+            // @Sendable Task captures it — Swift 6 rejects capturing a `var`
+            // that was mutated in the enclosing scope.
+            let hadFailures = !setFailures.isEmpty
+            let failureNote = hadFailures ? " setRawKey failures: \(setFailures.joined(separator: "; "))." : ""
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.activityLog?.log(
-                    category: .call, severity: setFailures.isEmpty ? .debug : .warning, source: "CallWidgetBridge",
+                    category: .call, severity: hadFailures ? .warning : .debug, source: "CallWidgetBridge",
                     summary: "Received E2EE key from \(sender)",
                     detail: "Routed to LiveKit participantIds: [\(identitiesJoined)]. Sender: \(sender), device: \(deviceId), member: \(memberId), index: \(index), sha256[0..8]: \(fp).\(failureNote)",
                     roomId: self.roomId

--- a/RelayKit/Call/LiveKitCredentialService.swift
+++ b/RelayKit/Call/LiveKitCredentialService.swift
@@ -195,6 +195,16 @@ struct LiveKitCredentialService {
                   !serviceURL.isEmpty
             else { continue }
 
+            // Never converge on our OWN membership. We're about to publish a
+            // fresh one, and a leftover entry from a previous session (not
+            // yet expired/tombstoned) can be the *oldest* — which would make
+            // us pick our own homeserver's SFU, momentarily share it with a
+            // peer who converged there, then split the call the instant our
+            // fresh membership flips the oldest_membership winner to the
+            // peer's SFU. `oldest_membership` must be computed over the
+            // other participants.
+            if (event["sender"] as? String) == userID { continue }
+
             // Drop expired memberships. Default `expires` is 4h
             // (14400000ms). `created_ts` falls back to event-level
             // `origin_server_ts` so very old non-tombstoned events still


### PR DESCRIPTION
Three MatrixRTC call fixes. The first two were authored on top of `rtc-element-call-alignment` but didn't make it into that merge; the third repairs a pre-existing Swift 6 build error in already-merged code.

## Fix joining an in-progress call
Joining a call that was already in progress sat on "waiting for participants" (it only worked when Relay joined first and others arrived after):

- Existing peers weren't enumerated. `participantDidConnect` only fires for peers who join after us; peers already present arrive in the initial `room.remoteParticipants` snapshot, which `connect()` never synced. We now `syncParticipants` right after connecting and push our E2EE key to each already-present peer.
- SFU convergence split the call. `fetchSFUFromCallMembers` (oldest_membership) counted our own `m.call.member`, so a stale entry could make us pick our own SFU, then flip the winner to a peer's SFU once our fresh membership published — stranding us. We now exclude our own memberships from discovery.

## Tear down call state on a failed connect
On a connect failure, `startCall`'s catch reported the error but left `activeCallViewModel` set, so the toolbar call button stayed disabled until app restart. The failure path now calls `callManager.endCall()` to disconnect and clear call state; the error is still surfaced via the banner.

## Fix Swift 6 Sendable-capture build error
`CallWidgetBridge`'s E2EE key-routing loop accumulated failures into a mutable `var setFailures`, then captured it in the `@Sendable` Task that logs the result — rejected under Swift 6 ("mutated after capture by sendable closure"). We snapshot it into immutable lets before the Task. No behaviour change. This is a pre-existing violation in already-merged code surfaced by the project's Swift 6 mode, not introduced by the commits above.
