### PR TITLE
Add screen sharing via the native macOS picker

### DIFF
--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
@@ -41,19 +41,27 @@ public struct CallParticipant: Identifiable, Sendable, Equatable {
     public let isMicrophoneEnabled: Bool
     /// Whether the participant is currently speaking.
     public let isSpeaking: Bool
+    /// Whether this snapshot represents a screen-share track rather than a
+    /// camera. Synthesized by the view model: a remote participant who
+    /// publishes a screen-share gets a second `CallParticipant` entry whose
+    /// `id` is suffixed with `"::screen"` and whose `isScreenShareEnabled`
+    /// is `true`. The view treats these like any other tile.
+    public let isScreenShareEnabled: Bool
 
     public init(
         id: String,
         displayName: String?,
         isCameraEnabled: Bool,
         isMicrophoneEnabled: Bool,
-        isSpeaking: Bool
+        isSpeaking: Bool,
+        isScreenShareEnabled: Bool = false
     ) {
         self.id = id
         self.displayName = displayName
         self.isCameraEnabled = isCameraEnabled
         self.isMicrophoneEnabled = isMicrophoneEnabled
         self.isSpeaking = isSpeaking
+        self.isScreenShareEnabled = isScreenShareEnabled
     }
 }
 
@@ -79,6 +87,9 @@ public protocol CallViewModelProtocol: AnyObject, Observable {
 
     /// Whether the local user's microphone is active.
     var isLocalMicrophoneEnabled: Bool { get }
+
+    /// Whether the local user is currently publishing a screen-share track.
+    var isLocalScreenShareEnabled: Bool { get }
 
     /// The identity of the local participant, set after connection.
     var localParticipantID: String? { get }
@@ -110,6 +121,17 @@ public protocol CallViewModelProtocol: AnyObject, Observable {
 
     /// Toggles the local microphone on or off.
     func toggleMicrophone() async throws
+
+    /// Starts the share-screen flow when off, or stops it when on.
+    ///
+    /// When starting, this presents the native macOS screen-share picker
+    /// (`SCContentSharingPicker`). Once the user chooses a display or
+    /// window, the captured frames are published as a LiveKit track. When
+    /// stopping, the published screen-share track is unpublished
+    /// immediately. The user can also stop the share from the macOS
+    /// menu-bar control, which the view model observes and reflects in
+    /// ``isLocalScreenShareEnabled``.
+    func toggleScreenShare() async throws
 
     /// Returns a SwiftUI view that renders the video track of the given participant,
     /// or `nil` if the participant has no active video track or is not found.

--- a/Relay/ViewModels/PreviewCallViewModel.swift
+++ b/Relay/ViewModels/PreviewCallViewModel.swift
@@ -27,6 +27,7 @@ final class PreviewCallViewModel: CallViewModelProtocol {
     var participants: [CallParticipant] = []
     var isLocalCameraEnabled: Bool = false
     var isLocalMicrophoneEnabled: Bool = false
+    var isLocalScreenShareEnabled: Bool = false
     var localParticipantID: String? = nil
     var videoTrackRevision: UInt = 0
     var connectingPhase: String? = nil
@@ -61,6 +62,7 @@ final class PreviewCallViewModel: CallViewModelProtocol {
         participants = []
         isLocalCameraEnabled = false
         isLocalMicrophoneEnabled = false
+        isLocalScreenShareEnabled = false
         localParticipantID = nil
     }
 
@@ -70,6 +72,12 @@ final class PreviewCallViewModel: CallViewModelProtocol {
 
     func toggleMicrophone() async throws {
         isLocalMicrophoneEnabled.toggle()
+    }
+
+    func toggleScreenShare() async throws {
+        // Previews don't touch ScreenCaptureKit; just flip the flag so the
+        // control-bar button reflects state.
+        isLocalScreenShareEnabled.toggle()
     }
 
     func makeVideoView(for participantID: String) -> AnyView? { nil }

--- a/Relay/Views/Call/CallView.swift
+++ b/Relay/Views/Call/CallView.swift
@@ -303,6 +303,15 @@ struct CallView: View {
                 Task { try? await viewModel.toggleCamera() }
             }
 
+            // Share screen toggle
+            controlButton(
+                icon: viewModel.isLocalScreenShareEnabled ? "rectangle.on.rectangle.fill" : "rectangle.on.rectangle",
+                isActive: viewModel.isLocalScreenShareEnabled,
+                help: viewModel.isLocalScreenShareEnabled ? "Stop Sharing" : "Share Screen"
+            ) {
+                Task { try? await viewModel.toggleScreenShare() }
+            }
+
             // End call
             Button {
                 // Disconnect — the .disconnected case in `body` calls

--- a/RelayKit/Call/CallViewModel.swift
+++ b/RelayKit/Call/CallViewModel.swift
@@ -33,6 +33,7 @@ public final class CallViewModel: CallViewModelProtocol {
     public private(set) var participants: [CallParticipant] = []
     public private(set) var isLocalCameraEnabled: Bool = false
     public private(set) var isLocalMicrophoneEnabled: Bool = false
+    public private(set) var isLocalScreenShareEnabled: Bool = false
     public private(set) var localParticipantID: String?
     /// Human-readable label for the current step inside `.connecting`.
     /// Updated as the connect path moves through credential exchange,
@@ -61,6 +62,18 @@ public final class CallViewModel: CallViewModelProtocol {
     /// "more Update Constraints in Window passes than there are views".
     @ObservationIgnored
     private var videoViewCache: [String: (trackObjectID: ObjectIdentifier, view: AnyView)] = [:]
+
+    // MARK: - Screen-share state
+
+    /// Drives the native `SCContentSharingPicker` + `SCStream` capture
+    /// pipeline. Non-nil only while a share is being set up or is active.
+    @ObservationIgnored
+    private var screenShareController: ScreenShareController?
+
+    /// The currently-active local screen-share publication, tracked so the
+    /// stop paths can unpublish it without scanning.
+    @ObservationIgnored
+    private var localScreenSharePublication: LocalTrackPublication?
 
     // MARK: - E2EE State
     //
@@ -517,6 +530,11 @@ public final class CallViewModel: CallViewModelProtocol {
         participants = []
         isLocalCameraEnabled = false
         isLocalMicrophoneEnabled = false
+        isLocalScreenShareEnabled = false
+        let screenController = screenShareController
+        Task { await screenController?.stop() }
+        screenShareController = nil
+        localScreenSharePublication = nil
         localParticipantID = nil
         videoViewCache.removeAll()
         localEncryptionKey = nil
@@ -621,13 +639,147 @@ public final class CallViewModel: CallViewModelProtocol {
         isLocalMicrophoneEnabled = enabled
     }
 
+    // MARK: - Screen share
+
+    public func toggleScreenShare() async throws {
+        if isLocalScreenShareEnabled {
+            await stopScreenShare(reason: "user toggle")
+            return
+        }
+        // Spin up the native picker. Capture begins (and the track gets
+        // published) only after the user chooses a source, via the
+        // controller callbacks wired below.
+        let controller = ScreenShareController(captureAppAudio: true)
+        controller.onTrackReady = { [weak self] track in
+            Task { await self?.publishScreenShareTrack(track) }
+        }
+        controller.onCancelled = { [weak self] in
+            self?.teardownScreenShareController()
+            self?.activityLog?.log(
+                category: .call, severity: .debug, source: "CallViewModel",
+                summary: "Screen-share picker dismissed without selection",
+                roomId: self?.roomID
+            )
+        }
+        controller.onStoppedExternally = { [weak self] reason in
+            Task { await self?.handleExternalScreenShareStop(reason: reason) }
+        }
+        controller.onError = { [weak self] error in
+            self?.teardownScreenShareController()
+            self?.isLocalScreenShareEnabled = false
+            self?.activityLog?.log(
+                category: .call, severity: .error, source: "CallViewModel",
+                summary: "Screen share failed to start",
+                detail: "macOS may have denied Screen Recording permission. Grant access in System Settings \u{203A} Privacy & Security \u{203A} Screen & System Audio Recording. Error: \(error.localizedDescription)",
+                roomId: self?.roomID
+            )
+        }
+        screenShareController = controller
+        controller.presentPicker()
+        activityLog?.log(
+            category: .call, severity: .debug, source: "CallViewModel",
+            summary: "Presented system screen-share picker",
+            roomId: roomID
+        )
+    }
+
+    /// Publishes the screen-share track produced by the controller once
+    /// the user has chosen a source.
+    private func publishScreenShareTrack(_ track: LocalVideoTrack) async {
+        do {
+            let publication = try await room.localParticipant.publish(videoTrack: track)
+            localScreenSharePublication = publication
+            isLocalScreenShareEnabled = true
+            videoTrackRevision += 1
+            activityLog?.log(
+                category: .call, severity: .info, source: "CallViewModel",
+                summary: "Started screen share",
+                detail: "Publication sid: \(publication.sid.stringValue). appAudio: true.",
+                roomId: roomID
+            )
+        } catch {
+            await screenShareController?.stop()
+            teardownScreenShareController()
+            isLocalScreenShareEnabled = false
+            localScreenSharePublication = nil
+            activityLog?.log(
+                category: .call, severity: .error, source: "CallViewModel",
+                summary: "Failed to publish screen-share track",
+                detail: error.localizedDescription,
+                roomId: roomID
+            )
+        }
+    }
+
+    /// Stops an active screen share initiated from within Relay (the user
+    /// tapped the toggle): tears down the capture stream and unpublishes.
+    private func stopScreenShare(reason: String) async {
+        await screenShareController?.stop()
+        teardownScreenShareController()
+        if let publication = localScreenSharePublication {
+            try? await room.localParticipant.unpublish(publication: publication)
+        }
+        let wasEnabled = isLocalScreenShareEnabled
+        localScreenSharePublication = nil
+        isLocalScreenShareEnabled = false
+        if let localID = localParticipantID {
+            videoViewCache.removeValue(forKey: "\(localID)::screen")
+        }
+        videoTrackRevision += 1
+        if wasEnabled {
+            activityLog?.log(
+                category: .call, severity: .info, source: "CallViewModel",
+                summary: "Stopped screen share",
+                detail: "Reason: \(reason).",
+                roomId: roomID
+            )
+        }
+    }
+
+    /// Handles the share ending from outside Relay — the user clicked
+    /// "Stop Sharing" in the macOS menu bar, or the `SCStream` failed. The
+    /// controller has already torn its stream down; we just unpublish.
+    private func handleExternalScreenShareStop(reason: String) async {
+        teardownScreenShareController()
+        if let publication = localScreenSharePublication {
+            try? await room.localParticipant.unpublish(publication: publication)
+        }
+        let wasEnabled = isLocalScreenShareEnabled
+        localScreenSharePublication = nil
+        isLocalScreenShareEnabled = false
+        if let localID = localParticipantID {
+            videoViewCache.removeValue(forKey: "\(localID)::screen")
+        }
+        videoTrackRevision += 1
+        if wasEnabled {
+            activityLog?.log(
+                category: .call, severity: .info, source: "CallViewModel",
+                summary: "Stopped screen share",
+                detail: "Reason: \(reason).",
+                roomId: roomID
+            )
+        }
+    }
+
+    private func teardownScreenShareController() {
+        screenShareController = nil
+    }
+
     public func videoAspectRatio(for participantID: String) -> CGFloat? {
-        let isLocal = room.localParticipant.identity?.stringValue == participantID
+        let (resolvedID, wantsScreenShare) = decomposeParticipantID(participantID)
+        let isLocal = room.localParticipant.identity?.stringValue == resolvedID
         let participant: Participant? = isLocal
             ? room.localParticipant
-            : room.remoteParticipants.values.first { $0.identity?.stringValue == participantID }
+            : room.remoteParticipants.values.first { $0.identity?.stringValue == resolvedID }
 
-        guard let publication = participant?.videoTracks.first,
+        let publication: TrackPublication?
+        if wantsScreenShare {
+            publication = participant?.videoTracks.first { $0.source == .screenShareVideo }
+        } else {
+            publication = participant?.videoTracks.first { $0.source != .screenShareVideo }
+                ?? participant?.videoTracks.first
+        }
+        guard let publication,
               !publication.isMuted,
               let track = publication.track as? VideoTrack else {
             return nil
@@ -639,13 +791,35 @@ public final class CallViewModel: CallViewModelProtocol {
         return CGFloat(dim.width) / CGFloat(dim.height)
     }
 
+    /// Splits a possibly-suffixed participant ID back into the underlying
+    /// LiveKit identity + a flag for which track surface the view wants.
+    /// `<base>::screen` → `(<base>, true)`, otherwise `(participantID, false)`.
+    private func decomposeParticipantID(_ participantID: String) -> (resolved: String, wantsScreenShare: Bool) {
+        let suffix = "::screen"
+        if participantID.hasSuffix(suffix) {
+            return (String(participantID.dropLast(suffix.count)), true)
+        }
+        return (participantID, false)
+    }
+
     public func makeVideoView(for participantID: String) -> AnyView? {
-        let isLocal = room.localParticipant.identity?.stringValue == participantID
+        // `::screen` suffix → resolve to the screen-share publication on the
+        // underlying participant rather than the first video track (which
+        // is the camera).
+        let (resolvedID, wantsScreenShare) = decomposeParticipantID(participantID)
+        let isLocal = room.localParticipant.identity?.stringValue == resolvedID
         let participant: Participant? = isLocal
             ? room.localParticipant
-            : room.remoteParticipants.values.first { $0.identity?.stringValue == participantID }
+            : room.remoteParticipants.values.first { $0.identity?.stringValue == resolvedID }
 
-        guard let publication = participant?.videoTracks.first,
+        let publication: TrackPublication?
+        if wantsScreenShare {
+            publication = participant?.videoTracks.first { $0.source == .screenShareVideo }
+        } else {
+            publication = participant?.videoTracks.first { $0.source != .screenShareVideo }
+                ?? participant?.videoTracks.first
+        }
+        guard let publication,
               !publication.isMuted,
               let track = publication.track as? VideoTrack
         else {
@@ -666,10 +840,13 @@ public final class CallViewModel: CallViewModelProtocol {
             return cached.view
         }
 
+        // A screen share is never mirrored — the user expects to see their
+        // shared screen as the peers see it, not flipped.
+        let mirror: VideoView.MirrorMode = (isLocal && !wantsScreenShare) ? .mirror : .off
         let view = AnyView(
             SwiftUIVideoView(track,
                              layoutMode: .fill,
-                             mirrorMode: isLocal ? .mirror : .off)
+                             mirrorMode: mirror)
         )
         videoViewCache[participantID] = (trackObjectID: trackID, view: view)
         return view
@@ -826,14 +1003,35 @@ public final class CallViewModel: CallViewModelProtocol {
     fileprivate func syncParticipants(trackChanged: Bool = false) {
         if trackChanged { videoTrackRevision += 1 }
 
-        let newParticipants = room.remoteParticipants.values.map { participant in
-            CallParticipant(
-                id: participant.identity?.stringValue ?? participant.sid?.stringValue ?? UUID().uuidString,
-                displayName: participant.name,
-                isCameraEnabled: participant.isCameraEnabled(),
-                isMicrophoneEnabled: participant.isMicrophoneEnabled(),
-                isSpeaking: participant.isSpeaking
+        var newParticipants: [CallParticipant] = []
+        for participant in room.remoteParticipants.values {
+            let baseID = participant.identity?.stringValue ?? participant.sid?.stringValue ?? UUID().uuidString
+            newParticipants.append(
+                CallParticipant(
+                    id: baseID,
+                    displayName: participant.name,
+                    isCameraEnabled: participant.isCameraEnabled(),
+                    isMicrophoneEnabled: participant.isMicrophoneEnabled(),
+                    isSpeaking: participant.isSpeaking
+                )
             )
+            // Synthesise a second tile for a remote screen-share. The
+            // suffixed id flows through the grid layout untouched; the
+            // video factory below resolves it back to the underlying
+            // LiveKit participant + screen-share publication.
+            if participant.isScreenShareEnabled() {
+                let baseName = participant.name ?? baseID
+                newParticipants.append(
+                    CallParticipant(
+                        id: "\(baseID)::screen",
+                        displayName: "\(baseName) (screen)",
+                        isCameraEnabled: true,
+                        isMicrophoneEnabled: false,
+                        isSpeaking: false,
+                        isScreenShareEnabled: true
+                    )
+                )
+            }
         }
 
         // Prune video view cache for participants who have left.
@@ -1163,6 +1361,9 @@ public final class CallViewModel: CallViewModelProtocol {
         }
 
         func room(_ room: LiveKit.Room, participant: LocalParticipant, didUnpublishTrack publication: LocalTrackPublication) {
+            // Screen-share stop (menu-bar or toggle) is driven by the
+            // ScreenShareController's SCStream callbacks, which unpublish
+            // and reset state. Here we just refresh the video revision.
             Task { @MainActor [weak viewModel] in
                 viewModel?.videoTrackRevision += 1
             }

--- a/RelayKit/Call/ScreenShareController.swift
+++ b/RelayKit/Call/ScreenShareController.swift
@@ -1,0 +1,241 @@
+// Copyright 2026 Link Dupont
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AVFoundation
+import CoreMedia
+import Foundation
+import LiveKit
+import ScreenCaptureKit
+
+/// Owns the native macOS screen-share pipeline and bridges it into LiveKit.
+///
+/// This is "Path A" from the screen-share design: rather than letting
+/// LiveKit's `MacOSScreenCapturer` enumerate and pick sources itself, we
+/// drive Apple's `SCContentSharingPicker` directly (so the user gets the
+/// same system picker FaceTime uses, plus the menu-bar presenter overlay /
+/// stop-sharing control for free), run our own `SCStream`, and feed the
+/// captured frames into a LiveKit `BufferCapturer`-backed track. App audio
+/// is mixed into the outgoing audio via `AudioManager.shared.mixer`, the
+/// same sink LiveKit's own capturer uses.
+///
+/// LiveKit can't accept the picker's `SCContentFilter` (its capturer
+/// resolves filters from internal `SCWindow`/`SCDisplay` objects we can't
+/// construct), which is why we own the stream end-to-end.
+///
+/// Callbacks are delivered on the main actor. The owner (``CallViewModel``)
+/// is responsible for publishing/unpublishing the track it receives via
+/// ``onTrackReady`` — this controller never touches the `Room`.
+final class ScreenShareController: NSObject, @unchecked Sendable {
+    /// Delivered once the user picks a source and the capture stream is
+    /// live. The owner should publish the track.
+    var onTrackReady: (@MainActor (LocalVideoTrack) -> Void)?
+    /// Delivered when the user dismissed the picker without choosing.
+    var onCancelled: (@MainActor () -> Void)?
+    /// Delivered when an active share ended outside the app's toggle —
+    /// e.g. the user clicked "Stop Sharing" in the macOS menu bar, or the
+    /// stream failed. The owner should unpublish and reset state.
+    var onStoppedExternally: (@MainActor (_ reason: String) -> Void)?
+    /// Delivered when starting capture failed (permission denied, stream
+    /// start error). The owner should surface this to the user.
+    var onError: (@MainActor (Error) -> Void)?
+
+    private let captureAppAudio: Bool
+    private let videoSampleQueue = DispatchQueue(label: "camera.relay.screenshare.video")
+    private let audioSampleQueue = DispatchQueue(label: "camera.relay.screenshare.audio")
+
+    private var stream: SCStream?
+    private var track: LocalVideoTrack?
+    // Read from the nonisolated sample-handler queue, written once on the
+    // main actor in `startCapture` before frames start flowing. The module
+    // defaults to main-actor isolation, so this needs `nonisolated(unsafe)`
+    // to be reachable from the capture queue; the write-before-frames
+    // ordering makes the access safe.
+    nonisolated(unsafe) private weak var bufferCapturer: BufferCapturer?
+
+    init(captureAppAudio: Bool) {
+        self.captureAppAudio = captureAppAudio
+        super.init()
+    }
+
+    /// Presents the system screen-share picker. The result arrives via the
+    /// `SCContentSharingPickerObserver` callbacks below.
+    @MainActor
+    func presentPicker() {
+        let picker = SCContentSharingPicker.shared
+        var configuration = SCContentSharingPickerConfiguration()
+        configuration.allowedPickerModes = [.singleDisplay, .singleWindow, .singleApplication]
+        picker.defaultConfiguration = configuration
+        picker.add(self)
+        picker.isActive = true
+        picker.present()
+    }
+
+    /// Stops an active share and tears down the stream. Safe to call when
+    /// nothing is active. Does not fire `onStoppedExternally` — the caller
+    /// initiated this, so it already knows.
+    @MainActor
+    func stop() async {
+        deactivatePicker()
+        if let stream {
+            try? await stream.stopCapture()
+        }
+        stream = nil
+        track = nil
+        bufferCapturer = nil
+    }
+
+    @MainActor
+    private func deactivatePicker() {
+        let picker = SCContentSharingPicker.shared
+        picker.remove(self)
+        // Only deactivate if no other consumer is using it. We're the only
+        // consumer in this app, so it's safe to flip off.
+        picker.isActive = false
+    }
+
+    // MARK: - Stream setup
+
+    @MainActor
+    private func startCapture(with filter: SCContentFilter) async {
+        let configuration = SCStreamConfiguration()
+        // Capture at the source's native pixel resolution.
+        let scale = filter.pointPixelScale
+        configuration.width = Int(filter.contentRect.width * CGFloat(scale))
+        configuration.height = Int(filter.contentRect.height * CGFloat(scale))
+        configuration.minimumFrameInterval = CMTime(value: 1, timescale: 30)
+        configuration.queueDepth = 5
+        configuration.pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        configuration.showsCursor = true
+        configuration.capturesAudio = captureAppAudio
+
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        do {
+            try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: videoSampleQueue)
+            if captureAppAudio {
+                try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: audioSampleQueue)
+            }
+
+            // BufferCapturer-backed track. `createBufferTrack` exposes the
+            // capturer back to us via `LocalVideoTrack.capturer`, which is
+            // how we push frames in `didOutputSampleBuffer`.
+            let track = LocalVideoTrack.createBufferTrack(
+                source: .screenShareVideo,
+                options: BufferCaptureOptions()
+            )
+            self.track = track
+            self.bufferCapturer = track.capturer as? BufferCapturer
+
+            try await stream.startCapture()
+            self.stream = stream
+            onTrackReady?(track)
+        } catch {
+            self.stream = nil
+            self.track = nil
+            self.bufferCapturer = nil
+            deactivatePicker()
+            onError?(error)
+        }
+    }
+
+    // MARK: - Audio bridging
+
+    /// Mixes ScreenCaptureKit app audio into the local participant's
+    /// outgoing audio. Uses LiveKit's `CMSampleBuffer.toAVAudioPCMBuffer()`
+    /// helper — the same conversion its own `MacOSScreenCapturer` uses,
+    /// which builds the format via `AVAudioFormat(cmAudioFormatDescription:)`
+    /// and so preserves the non-interleaved channel layout SCStream
+    /// delivers. Called from the nonisolated audio sample-handler queue.
+    nonisolated private func handleAudio(_ sampleBuffer: CMSampleBuffer) {
+        guard let pcm = sampleBuffer.toAVAudioPCMBuffer() else { return }
+        AudioManager.shared.mixer.capture(appAudio: pcm)
+    }
+}
+
+// MARK: - SCContentSharingPickerObserver
+
+extension ScreenShareController: SCContentSharingPickerObserver {
+    // `SCContentSharingPickerObserver` is a `@MainActor` protocol, but
+    // ScreenCaptureKit delivers these callbacks over XPC on the replayd
+    // background queue. Leaving the conformance main-actor-isolated makes
+    // the Swift runtime insert an executor precondition that fails the
+    // instant a filter is selected. We mark the witnesses `nonisolated`
+    // and hop to the main actor ourselves.
+    nonisolated func contentSharingPicker(_: SCContentSharingPicker, didUpdateWith filter: SCContentFilter, for _: SCStream?) {
+        // `SCContentFilter` isn't `Sendable`. We're the sole consumer and
+        // hand it straight to the main actor for one-shot use, so the
+        // cross-actor move is safe.
+        nonisolated(unsafe) let filter = filter
+        Task { @MainActor [weak self] in
+            await self?.startCapture(with: filter)
+        }
+    }
+
+    nonisolated func contentSharingPicker(_: SCContentSharingPicker, didCancelFor _: SCStream?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.deactivatePicker()
+            self.onCancelled?()
+        }
+    }
+
+    nonisolated func contentSharingPickerStartDidFailWithError(_ error: Error) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.deactivatePicker()
+            self.onError?(error)
+        }
+    }
+}
+
+// MARK: - SCStreamDelegate
+
+extension ScreenShareController: SCStreamDelegate {
+    nonisolated func stream(_: SCStream, didStopWithError error: Error) {
+        // Fires when the user stops the share from the macOS menu-bar
+        // control, or the stream dies. Called on a background queue —
+        // hop to main before touching our state or the owner.
+        let description = error.localizedDescription
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.stream = nil
+            self.track = nil
+            self.bufferCapturer = nil
+            self.deactivatePicker()
+            self.onStoppedExternally?(description)
+        }
+    }
+}
+
+// MARK: - SCStreamOutput
+
+extension ScreenShareController: SCStreamOutput {
+    // Like the picker observer, `SCStreamOutput` is main-actor-isolated in
+    // the SDK, but SCStream delivers sample buffers on the
+    // `sampleHandlerQueue` we passed. `nonisolated` drops the executor
+    // precondition so frames don't crash the capture queue; everything
+    // here is queue-safe (`BufferCapturer.capture` and the audio mixer
+    // are both designed to be fed from a capture thread).
+    nonisolated func stream(_: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        switch type {
+        case .screen:
+            guard sampleBuffer.isValid,
+                  CMSampleBufferGetImageBuffer(sampleBuffer) != nil else { return }
+            bufferCapturer?.capture(sampleBuffer)
+        case .audio:
+            handleAudio(sampleBuffer)
+        @unknown default:
+            break
+        }
+    }
+}

--- a/RelayKit/Call/ScreenShareController.swift
+++ b/RelayKit/Call/ScreenShareController.swift
@@ -234,6 +234,11 @@ extension ScreenShareController: SCStreamOutput {
             bufferCapturer?.capture(sampleBuffer)
         case .audio:
             handleAudio(sampleBuffer)
+        case .microphone:
+            // The macOS 26 SDK can deliver the participant's microphone on the
+            // screen stream. We don't route it here — their mic is already
+            // published as the call's normal LiveKit audio track — so ignore it.
+            break
         @unknown default:
             break
         }


### PR DESCRIPTION
Adds a **Share Screen** control to the call window, backed by Apple's `SCContentSharingPicker` — the same system picker FaceTime uses. Users can share a display, a window, or an app, and get the menu-bar presenter overlay and stop-sharing control for free.

Closes #136 

### How it works
- **`ScreenShareController`** drives `SCContentSharingPicker` → owns an `SCStream` from the chosen `SCContentFilter` → feeds frames into a LiveKit `BufferCapturer`-backed track and publishes it. We own the `SCStream` end-to-end because LiveKit's `MacOSScreenCapturer` resolves filters from internal `SCWindow`/`SCDisplay` objects that can't be constructed from the picker's output.
- **App audio** is mixed into the outgoing track via `AudioManager.shared.mixer`, matching LiveKit's own app-audio path.
- A remote peer's share is surfaced as a **synthetic participant tile** (id suffixed `::screen`), so the existing call grid renders it with no view-layer changes; `makeVideoView`/`videoAspectRatio` resolve the suffix to the peer's `screenShareVideo` publication.

### Concurrency
The target uses default main-actor isolation, but ScreenCaptureKit delivers picker/stream callbacks on background queues. Those callbacks (picker observer, `SCStreamOutput`, `SCStreamDelegate`) are marked `nonisolated` and hop to the main actor themselves; picker/stream lifecycle stays `@MainActor`.

### Encryption & permissions
- Reuses the existing per-participant E2EE key — screen-share tracks are encrypted identically to camera, no extra key plumbing.
- **No new permissions or entitlements.** `SCContentSharingPicker` is itself the consent mechanism (the user's selection grants a scoped `SCContentFilter`), so — like FaceTime — Relay needs neither the global Screen Recording TCC grant nor a usage-description string, and won't appear in System Settings' Screen & System Audio Recording list. App audio rides the existing `device.audio-input` entitlement.

The second commit handles the macOS 26 SDK's new `SCStreamOutputType.microphone` case (ignored — the participant's mic is already the call's normal audio track).