### PR TITLE
Re-measure timeline row when a collapsed event group expands

### DIFF
--- a/Relay/Views/Timeline/TimelineActions.swift
+++ b/Relay/Views/Timeline/TimelineActions.swift
@@ -23,6 +23,14 @@ import SwiftUI
 final class ExpandedGroupsState {
     var expandedIDs: Set<String> = []
 
+    /// Invoked after a group's expansion state changes, with the group's ID.
+    /// The table-backed renderer (``TimelineTableViewController``) uses this to
+    /// re-measure the affected row: expanding/collapsing changes the row's
+    /// content height without changing the underlying message data, so the
+    /// height cache would otherwise keep the stale (collapsed) value and clip
+    /// the expanded content.
+    @ObservationIgnored var onToggle: ((String) -> Void)?
+
     func isExpanded(_ groupID: String) -> Bool {
         expandedIDs.contains(groupID)
     }
@@ -33,6 +41,7 @@ final class ExpandedGroupsState {
         } else {
             expandedIDs.insert(groupID)
         }
+        onToggle?(groupID)
     }
 }
 

--- a/Relay/Views/Timeline/TimelineTableView.swift
+++ b/Relay/Views/Timeline/TimelineTableView.swift
@@ -818,6 +818,42 @@ final class TimelineTableViewController: NSViewController {
         }
     }
 
+    /// Re-measures a single row whose content height changed without any
+    /// change to the underlying message data — specifically when a collapsed
+    /// system-event group is expanded or collapsed.
+    ///
+    /// `updateRows` only re-measures when `rows` diff, which they don't here
+    /// (only the shared ``ExpandedGroupsState`` flipped). We invalidate the
+    /// cached height for this row and note its new height; `heightOfRow`'s
+    /// measurement host rebuilds the row reading the now-updated expansion
+    /// state, so it returns the full expanded (or collapsed) height.
+    func remeasureRow(forMessageID id: String) {
+        guard let messageIndex = rows.firstIndex(where: { $0.id == id }) else { return }
+        let sentinelOffset = typingUsers.isEmpty ? 0 : 1
+        let rowIndex = messageIndex + sentinelOffset
+
+        // Defer so the live hosting cell has settled its SwiftUI re-render
+        // before we note the new height (matches the resize handler).
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.invalidateHeight(for: id)
+            let scrollBefore = self.scrollView.contentView.bounds.origin
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                context.allowsImplicitAnimation = false
+                self.tableView.noteHeightOfRows(withIndexesChanged: IndexSet(integer: rowIndex))
+            }
+            // Preserve the scroll position; growing a row above the viewport
+            // would otherwise shift the visible content.
+            if self.isNearBottom {
+                self.scrollToBottom(animated: false)
+            } else if abs(scrollBefore.y - self.scrollView.contentView.bounds.origin.y) > 0.5 {
+                self.scrollView.contentView.scroll(to: scrollBefore)
+                self.scrollView.reflectScrolledClipView(self.scrollView.contentView)
+            }
+        }
+    }
+
     // MARK: - Resize Handling
 
     @objc private func viewDidResize(_ notification: Notification) {

--- a/Relay/Views/Timeline/TimelineTableView.swift
+++ b/Relay/Views/Timeline/TimelineTableView.swift
@@ -834,7 +834,7 @@ final class TimelineTableViewController: NSViewController {
 
         // Defer so the live hosting cell has settled its SwiftUI re-render
         // before we note the new height (matches the resize handler).
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             self.invalidateHeight(for: id)
             let scrollBefore = self.scrollView.contentView.bounds.origin

--- a/Relay/Views/Timeline/TimelineTableViewRepresentable.swift
+++ b/Relay/Views/Timeline/TimelineTableViewRepresentable.swift
@@ -69,6 +69,15 @@ struct TimelineTableViewRepresentable: NSViewControllerRepresentable {
 
     private func configureCallbacks(_ vc: TimelineTableViewController, context: Context) {
         let actions = actions
+
+        // When a collapsed system-event group is expanded/collapsed, the row's
+        // content height changes without a `rows` diff, so the table must be
+        // told to re-measure that row (otherwise it stays clipped at the
+        // cached collapsed height).
+        actions.expandedGroups.onToggle = { [weak vc] groupID in
+            vc?.remeasureRow(forMessageID: groupID)
+        }
+
         vc.callbacks = .init(
             onNearBottomChanged: onNearBottomChanged,
             onPaginateBackward: onPaginateBackward,


### PR DESCRIPTION
Fixes #150 — expanding a collapsed list of call/system events would clip the content and push the timeline off screen.

### Cause
The table-backed timeline renderer caches row heights keyed by `(messageID, width)`. Expanding a collapsed group only flips the shared `@Observable ExpandedGroupsState` — it doesn't change the `rows` data, so `updateRows` never diffs that row, the height cache keeps the **collapsed** value, and `heightOfRow` returns it. NSTableView then clips the taller expanded content to the old height, and the un-accounted-for growth throws off scroll position.

### Fix
- `ExpandedGroupsState.toggle` now fires an `onToggle(groupID)` callback after mutating.
- The table controller's new `remeasureRow(forMessageID:)` invalidates that row's cached height and calls `noteHeightOfRows`. `heightOfRow`'s measurement host rebuilds the row reading the updated expansion state, so it returns the full expanded (or collapsed) height.
- Scroll position is preserved across the height change, so expanding a row above the viewport no longer shifts the visible content off screen.
- The representable wires `expandedGroups.onToggle` to the controller.

The LazyVStack renderer auto-sizes and was never affected — this is specific to the table renderer's height cache.

### Testing
- Expand/collapse a collapsed group of call/membership events → the row grows/shrinks to fit instead of clipping, and the timeline stays put.
