### PR TITLE
Anchor the reaction picker above the message bubble

### DIFF
--- a/Relay/Views/Message/MessageView.swift
+++ b/Relay/Views/Message/MessageView.swift
@@ -36,6 +36,11 @@ struct MessageView: View {
     /// timeline, allowing the reply preview bubble to be omitted.
     var replyIsAdjacentAbove: Bool = false
 
+    /// Reports the bubble's global frame as it changes, so the enclosing row
+    /// can anchor the reaction picker to the precise bubble (not the whole
+    /// row, which would include the avatar gutter).
+    var onBubbleFrameChange: ((CGRect) -> Void)? = nil
+
     /// Whether the reply-to message is adjacent above *and* on the same side
     /// (both incoming or both outgoing). Only in this case can we skip the
     /// preview bubble, since the user can see the original directly above.
@@ -157,9 +162,16 @@ struct MessageView: View {
         }
         .padding(.top, hasTopOverlay ? 11 : 0)
         .onGeometryChange(for: CGRect.self) { proxy in
-            proxy.frame(in: .named("timeline"))
+            proxy.frame(in: .global)
         } action: { newFrame in
             bubbleFrame = newFrame
+            // Keep an open reaction picker anchored to this bubble across
+            // layout changes (the timeline ignores this unless this message's
+            // picker is currently open).
+            actions.updateReactionPickerFrame(message.eventID, newFrame)
+            // Report the precise bubble frame up so the row can present the
+            // context-menu picker against the bubble, not the whole row.
+            onBubbleFrameChange?(newFrame)
         }
         .onLongPressGesture {
             presentReactionPickerForBubble()

--- a/Relay/Views/Pickers/ReactionPickerOverlay.swift
+++ b/Relay/Views/Pickers/ReactionPickerOverlay.swift
@@ -50,19 +50,16 @@ struct ReactionPickerOverlay: View {
                 .ignoresSafeArea()
                 .onTapGesture { onDismiss() }
 
-            // Anchor the capsule's BOTTOM edge `gap` above the bubble's top,
-            // edge-aligned to the bubble. Bottom/side padding within the
-            // (un-expanded) overlay bounds pins it deterministically — no
-            // capsule-size measurement, so it never overlaps the message.
+            // Anchor the capsule's bottom edge `gap` above the bubble's top.
+            // Outgoing: trailing-aligned to the bubble's trailing edge.
+            // Incoming: leading-aligned to the bubble's leading edge so the
+            // capsule extends rightward into the visible timeline area.
             GeometryReader { geo in
                 // Convert the bubble's global frame into this overlay's local
                 // space by subtracting the overlay's own global origin.
                 let origin = geo.frame(in: .global).origin
                 let bubble = bubbleFrame.offsetBy(dx: -origin.x, dy: -origin.y)
                 let bottomInset = max(0, geo.size.height - (bubble.minY - gap))
-                // Align the capsule's trailing edge to the bubble's trailing
-                // edge (for both incoming and outgoing messages).
-                let trailingInset = max(0, geo.size.width - bubble.maxX)
 
                 ReactionPickerCapsule { emoji in
                     onSelect(emoji)
@@ -70,11 +67,16 @@ struct ReactionPickerOverlay: View {
                 }
                 .fixedSize()
                 .padding(.bottom, bottomInset)
-                .padding(.trailing, trailingInset)
+                .padding(
+                    isOutgoing ? .trailing : .leading,
+                    isOutgoing
+                        ? max(0, geo.size.width - bubble.maxX)
+                        : max(0, bubble.minX)
+                )
                 .frame(
                     width: geo.size.width,
                     height: geo.size.height,
-                    alignment: .bottomTrailing
+                    alignment: isOutgoing ? .bottomTrailing : .bottomLeading
                 )
             }
         }

--- a/Relay/Views/Pickers/ReactionPickerOverlay.swift
+++ b/Relay/Views/Pickers/ReactionPickerOverlay.swift
@@ -15,12 +15,16 @@
 import SwiftUI
 
 /// A full-area overlay that dims the timeline and presents a ``ReactionPickerCapsule``
-/// above the target message bubble.
+/// just above the target message bubble.
 ///
-/// Presented at the ``TimelineView`` level so the dimming effect covers the
-/// entire message list. Tapping the dimmed backdrop dismisses the overlay.
+/// Presented at the ``TimelineView`` level so the dimming covers the whole
+/// message list and the capsule can extend beyond any single row. Tapping the
+/// dimmed backdrop dismisses the overlay.
 struct ReactionPickerOverlay: View {
-    /// The frame of the message bubble in the overlay's coordinate space.
+    /// The frame of the message bubble in **global** (window) coordinates.
+    /// Captured this way because it must cross the table renderer's per-row
+    /// `NSHostingView` boundary, where a named timeline coordinate space can't
+    /// resolve. The overlay converts it to its own local space below.
     let bubbleFrame: CGRect
 
     /// Whether the target message is outgoing (determines capsule alignment).
@@ -33,45 +37,47 @@ struct ReactionPickerOverlay: View {
     let onDismiss: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
-    @State private var capsuleSize: CGSize = .zero
+
+    /// Vertical gap between the bottom of the capsule and the top of the bubble.
+    private let gap: CGFloat = 8
 
     var body: some View {
         ZStack {
-            // Dimmed backdrop — darker in dark mode, lighter fog in light mode
+            // Dimmed backdrop — darker in dark mode, lighter fog in light mode.
+            // Kept as its own layer so its `.ignoresSafeArea()` expansion can't
+            // grow the capsule's alignment container. Tapping it dismisses.
             (colorScheme == .dark ? Color.black.opacity(0.3) : Color.black.opacity(0.1))
                 .ignoresSafeArea()
                 .onTapGesture { onDismiss() }
 
-            // Capsule positioned above the bubble, edge-aligned
-            ReactionPickerCapsule { emoji in
-                onSelect(emoji)
-                onDismiss()
+            // Anchor the capsule's BOTTOM edge `gap` above the bubble's top,
+            // edge-aligned to the bubble. Bottom/side padding within the
+            // (un-expanded) overlay bounds pins it deterministically — no
+            // capsule-size measurement, so it never overlaps the message.
+            GeometryReader { geo in
+                // Convert the bubble's global frame into this overlay's local
+                // space by subtracting the overlay's own global origin.
+                let origin = geo.frame(in: .global).origin
+                let bubble = bubbleFrame.offsetBy(dx: -origin.x, dy: -origin.y)
+                let bottomInset = max(0, geo.size.height - (bubble.minY - gap))
+                // Align the capsule's trailing edge to the bubble's trailing
+                // edge (for both incoming and outgoing messages).
+                let trailingInset = max(0, geo.size.width - bubble.maxX)
+
+                ReactionPickerCapsule { emoji in
+                    onSelect(emoji)
+                    onDismiss()
+                }
+                .fixedSize()
+                .padding(.bottom, bottomInset)
+                .padding(.trailing, trailingInset)
+                .frame(
+                    width: geo.size.width,
+                    height: geo.size.height,
+                    alignment: .bottomTrailing
+                )
             }
-            .onGeometryChange(for: CGSize.self) { proxy in
-                proxy.size
-            } action: { newSize in
-                capsuleSize = newSize
-            }
-            .position(capsulePosition)
         }
         .transition(.opacity)
-    }
-
-    /// Computes the center point for the capsule, placing it above the bubble
-    /// and edge-aligned so the capsule's trailing edge matches the bubble's
-    /// trailing edge (outgoing) or its leading edge matches the bubble's
-    /// leading edge (incoming).
-    private var capsulePosition: CGPoint {
-        let y = bubbleFrame.minY - 12
-        let halfWidth = capsuleSize.width / 2
-        let x: CGFloat
-        if isOutgoing {
-            // Align the capsule's trailing edge to the bubble's trailing edge.
-            x = bubbleFrame.maxX - halfWidth
-        } else {
-            // Align the capsule's leading edge to the bubble's leading edge.
-            x = bubbleFrame.minX + halfWidth
-        }
-        return CGPoint(x: x, y: y)
     }
 }

--- a/Relay/Views/Timeline/TimelineActions.swift
+++ b/Relay/Views/Timeline/TimelineActions.swift
@@ -74,8 +74,19 @@ final class TimelineActions: Equatable {
     var contextAction: (TimelineRowContextAction) -> Void = { _ in }
 
     /// Presents the reaction picker overlay for a message. Parameters:
-    /// (event ID, bubble frame in the timeline coordinate space, isOutgoing).
+    /// (event ID, bubble frame in **global** coordinates, isOutgoing).
+    ///
+    /// Global coordinates are used so the frame survives crossing the table
+    /// renderer's per-row `NSHostingView` boundary (a named timeline coordinate
+    /// space can't resolve inside a cell); the overlay converts to its local
+    /// space.
     var presentReactionPicker: (String, CGRect, Bool) -> Void = { _, _, _ in }
+
+    /// Streams a message's latest global bubble frame. While that message's
+    /// reaction picker is open, the timeline uses it to keep the picker
+    /// anchored to the bubble as the layout changes (e.g. a window resize).
+    /// Parameters: (event ID, bubble frame in global coordinates).
+    var updateReactionPickerFrame: (String, CGRect) -> Void = { _, _ in }
 
     /// Dismisses the highlight animation on the currently highlighted message.
     var highlightDismissed: () -> Void = {}

--- a/Relay/Views/Timeline/TimelineRowView.swift
+++ b/Relay/Views/Timeline/TimelineRowView.swift
@@ -164,16 +164,15 @@ struct TimelineRowView: View, Equatable {
                 message: message,
                 isLastInGroup: info.isLastInGroup,
                 showSenderName: info.showSenderName,
-                replyIsAdjacentAbove: info.replyIsAdjacentAbove
+                replyIsAdjacentAbove: info.replyIsAdjacentAbove,
+                // Track the precise bubble frame (MessageView is the single
+                // source — capturing here would report the whole row including
+                // the avatar gutter and fight the bubble's own updates).
+                onBubbleFrameChange: { lastBubbleFrame = $0 }
             )
             .id(message.id)
             .help(message.formattedTime)
             .onAppear { onAppear(row) }
-            .onGeometryChange(for: CGRect.self) { proxy in
-                proxy.frame(in: .named("timeline"))
-            } action: { newFrame in
-                lastBubbleFrame = newFrame
-            }
             .contextMenu {
                 contextMenu
             }

--- a/Relay/Views/Timeline/TimelineView.swift
+++ b/Relay/Views/Timeline/TimelineView.swift
@@ -542,11 +542,18 @@ struct TimelineView: View { // swiftlint:disable:this type_body_length
             self.handleContextAction(action)
         }
         actions.presentReactionPicker = { messageId, bubbleFrame, isOutgoing in
+            // `bubbleFrame` is in global coordinates; the overlay converts it.
             self.reactionPickerBubbleFrame = bubbleFrame
             self.reactionPickerIsOutgoing = isOutgoing
             withAnimation(.easeOut(duration: 0.15)) {
                 self.reactionPickerMessageId = messageId
             }
+        }
+        actions.updateReactionPickerFrame = { messageId, bubbleFrame in
+            // Track the bubble only while its picker is open, so the picker
+            // follows the message across layout changes (e.g. window resize).
+            guard messageId == self.reactionPickerMessageId else { return }
+            self.reactionPickerBubbleFrame = bubbleFrame
         }
         actions.highlightDismissed = {
             self.highlightedMessageId = nil


### PR DESCRIPTION
Fixes #147 — the reaction picker rendered fixed near the center, off in a corner, or overlapping/under the compose bar instead of attached to its message.

### Cause
The default timeline renderer is NSTableView-backed, with each row in its own `NSHostingView`. The picker was positioned from a bubble frame captured in the SwiftUI `"timeline"` coordinate space, but a named coordinate space can't resolve across that per-cell hosting boundary — so the frame was meaningless and the picker landed wherever.

### Fix
- **Capture the bubble frame in global (window) coordinates.** This is consistent across both the table and LazyVStack renderers and survives the `NSHostingView` boundary. `ReactionPickerOverlay` converts it into its own local space by subtracting its global origin.
- **Deterministic vertical anchor.** The capsule's bottom edge is pinned a small gap above the bubble's top using padding within the overlay bounds — no capsule-size measurement, which previously lagged a frame and overlapped the message. The capsule's trailing edge aligns to the bubble's trailing edge.
- **Single source of the bubble frame.** `MessageView` streams its precise bubble frame so the picker tracks the message across layout changes (e.g. window resize), and reports the same frame up to the row for the context-menu present. This removes a second, whole-row geometry stream that previously fought it and slid the picker onto the avatar gutter when the window narrowed.

### Testing
- Open the picker (smiley button, long-press, or "Add Reaction") on incoming and outgoing messages, one-line and multi-line → it sits just above the bubble, trailing-aligned, clear of the compose bar.
- Resize the window (width and height) with the picker open → it stays anchored to the bubble.
