### PR TITLE
Fix NavigationSplitView overflow at small window with a wide sidebar

### DIFF
--- a/Relay/ContentView.swift
+++ b/Relay/ContentView.swift
@@ -56,7 +56,12 @@ struct ContentView: View {
             }
         }
         .relayErrorAlert()
-        .frame(minWidth: 700, minHeight: 500)
+        // Sized to fit a quarter-screen tile on a 14" MacBook Pro at its
+        // default scaled resolution (1512×982 pt → quarter ≈ 756×491), with a
+        // few points of margin for macOS tiling gaps. The width must also clear
+        // the sidebar overflow invariant: rail 52 + sidebar max 300 + a usable
+        // timeline (400) = 752.
+        .frame(minWidth: 752, minHeight: 480)
     }
 }
 

--- a/Relay/Views/MainView.swift
+++ b/Relay/Views/MainView.swift
@@ -248,7 +248,12 @@ struct MainView: View { // swiftlint:disable:this type_body_length
                 spaceRailView
             }
         }
-        .navigationSplitViewColumnWidth(min: 160, ideal: 300, max: 360)
+        // Keep the sidebar narrow enough that, even at its max, it plus the
+        // 52pt space rail and a usable timeline fit inside the 760pt minimum
+        // window — otherwise NavigationSplitView overflows the window (the
+        // sidebar shoves off the left edge and the detail spills past the
+        // right) instead of compressing the user-dragged sidebar.
+        .navigationSplitViewColumnWidth(min: 160, ideal: 280, max: 300)
     }
 
     // MARK: - Detail


### PR DESCRIPTION
At the minimum window width, dragging the room-list sidebar wide pushed the split-view content past the window — the sidebar shoved off the left edge and the detail pane spilled past the right, clipping content (the timeline looked like it was clipping its rows).

### Cause
The window minimum (700pt) was smaller than `rail (52) + sidebar max (360) + a usable timeline`. When the user-dragged sidebar plus the detail's content couldn't both fit, `NavigationSplitView` overflowed the window instead of compressing the (sticky) sidebar. Logging confirmed the detail pane's frame growing past the visible window width while the sidebar was pushed to a negative x. The row heights themselves were always measured correctly — the apparent "row clipping" was content spilling past the window edge.

### Fix
Restore the invariant `window.min ≥ rail + sidebar.max + timeline.min`, balanced across both levers so neither changes much:
- **Sidebar max** 360 → 300 (ideal 300 → 280).
- **Window min** 700 → 752 (height 500 → 480). Worst case now fits: `52 + 300 + 400 = 752`.

The 752×480 minimum also fits a quarter-screen tile on a 14″ MacBook Pro at its default scaled resolution (1512×982 pt → quarter ≈ 756×491), with a few points of margin for macOS tiling gaps, so the window snaps cleanly into a 2×2 grid.

### Testing
- Window at minimum, sidebar dragged to its max → no clipping; sidebar stays fully on-screen, timeline content not cut off.
- Window tiles cleanly into a quarter on a 14″ MBP (default scaling).
