### PR TITLE
Add on-device live captions for remote call participants

### DIFF
--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
@@ -124,4 +124,21 @@ public protocol CallViewModelProtocol: AnyObject, Observable {
     ///
     /// - Parameter participantID: The ``CallParticipant/id`` of the participant.
     func videoAspectRatio(for participantID: String) -> CGFloat?
+
+    /// Whether on-device live captions are currently enabled for remote
+    /// participants. When `true`, each subscribed remote audio track is
+    /// piped into Apple's `SpeechAnalyzer` and the latest transcription is
+    /// surfaced via ``captions``.
+    var isCaptionsEnabled: Bool { get }
+
+    /// Latest caption text for each remote participant whose audio is being
+    /// transcribed, keyed by ``CallParticipant/id``. Empty when captions are
+    /// disabled or no remote has spoken yet. Final captions clear after a
+    /// short fade window so the UI doesn't show stale text.
+    var captions: [String: String] { get }
+
+    /// Toggles live captions on or off. Off → on attaches a transcriber to
+    /// each currently-subscribed remote audio track (and to any subscribed
+    /// later); on → off tears them all down and clears ``captions``.
+    func setCaptionsEnabled(_ enabled: Bool) async
 }

--- a/Relay/ViewModels/PreviewCallViewModel.swift
+++ b/Relay/ViewModels/PreviewCallViewModel.swift
@@ -74,4 +74,11 @@ final class PreviewCallViewModel: CallViewModelProtocol {
 
     func makeVideoView(for participantID: String) -> AnyView? { nil }
     func videoAspectRatio(for participantID: String) -> CGFloat? { 16.0 / 9.0 }
+
+    var isCaptionsEnabled: Bool = false
+    var captions: [String: String] = [:]
+    func setCaptionsEnabled(_ enabled: Bool) async {
+        isCaptionsEnabled = enabled
+        if !enabled { captions.removeAll() }
+    }
 }

--- a/Relay/Views/Call/CallView.swift
+++ b/Relay/Views/Call/CallView.swift
@@ -15,6 +15,124 @@
 import RelayInterface
 import SwiftUI
 
+// MARK: - Caption Helpers
+
+/// Word-aware wrapping for closed-caption text. Greedy fills lines up to
+/// `lineLength` characters, breaking only on whitespace; if a single word
+/// exceeds `lineLength` it hard-breaks (rare for English speech, common
+/// for URLs). Keeps only the last `maxLines` lines so the most recent
+/// words always survive.
+///
+/// Defaults follow Netflix's Timed Text Style Guide for English subtitles:
+/// **42 characters per line, max 2 lines visible**. Source:
+/// <https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394>
+fileprivate func wrapForCaptions(_ text: String, lineLength: Int = 42, maxLines: Int = 2) -> String {
+    let words = text.split(whereSeparator: \.isWhitespace).map(String.init)
+    guard !words.isEmpty else { return "" }
+
+    var lines: [String] = []
+    var current = ""
+
+    func push(_ line: String) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty { lines.append(trimmed) }
+    }
+
+    for word in words {
+        // Hard-break a word that's individually longer than the line.
+        if word.count > lineLength {
+            if !current.isEmpty { push(current); current = "" }
+            var remaining = Substring(word)
+            while remaining.count > lineLength {
+                push(String(remaining.prefix(lineLength)))
+                remaining = remaining.dropFirst(lineLength)
+            }
+            current = String(remaining)
+            continue
+        }
+
+        let candidate = current.isEmpty ? word : current + " " + word
+        if candidate.count > lineLength {
+            push(current)
+            current = word
+        } else {
+            current = candidate
+        }
+    }
+    push(current)
+
+    if lines.count > maxLines {
+        lines = Array(lines.suffix(maxLines))
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// CC-styled caption rectangle used by both the 1:1 layout and the group
+/// `ParticipantTile`. White on near-opaque black with a hairline edge and
+/// a tight glyph shadow — readable against any video frame.
+///
+/// Renders each visible line as a separate `Text` view in a VStack:
+///
+/// - Stable (committed) lines are identified by their content. They use
+///   asymmetric move-edge transitions so older lines slide off the top
+///   and new lines slide in from the bottom.
+/// - The bottom (in-progress) line uses a constant id `captionCurrentLine`
+///   so its character-level revisions are recognised as content changes
+///   on the same view rather than an insert/remove pair.
+/// - `clipShape` cuts the move animations to the rounded background so
+///   they look like content scrolling inside the caption box.
+///
+/// The box hugs its widest visible line — a `frame(maxWidth: 540)` caps
+/// the upper bound but the rect shrinks for shorter content because no
+/// child claims `.infinity` width.
+fileprivate func captionStrip(_ text: String) -> some View {
+    let allLines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    // Netflix style: max 2 visible lines. Older content rolls off the top.
+    let visibleLines = Array(allLines.suffix(2))
+    let stableLines = Array(visibleLines.dropLast())
+    let currentLine = visibleLines.last
+
+    // No transitions, no animations — captions roll up by simply
+    // updating in place. Any fade or move on a fast-changing live caption
+    // reads as visual noise; instant updates are calmer.
+    return VStack(spacing: 2) {
+        ForEach(stableLines, id: \.self) { line in
+            captionLineText(line)
+        }
+        if let currentLine, !currentLine.isEmpty {
+            captionLineText(currentLine)
+                .id("captionCurrentLine")
+        }
+    }
+    .transaction { $0.animation = nil }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(
+        Color.black.opacity(0.85),
+        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+    )
+    .overlay(
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .strokeBorder(Color.white.opacity(0.10), lineWidth: 0.5)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    .frame(maxWidth: 540)
+    .fixedSize(horizontal: false, vertical: true)
+}
+
+/// One styled caption line. `.lineLimit(1)` is safe because
+/// `wrapForCaptions` already breaks long text on word boundaries; this
+/// also lets the VStack hug its widest line for a snug box width.
+@ViewBuilder
+fileprivate func captionLineText(_ text: String) -> some View {
+    Text(text)
+        .font(.system(.title3, design: .default, weight: .semibold))
+        .foregroundStyle(.white)
+        .multilineTextAlignment(.center)
+        .lineLimit(1)
+        .shadow(color: .black.opacity(0.9), radius: 1)
+}
+
 /// Renders a LiveKit audio/video call with a FaceTime-inspired design.
 ///
 /// The call opens in its own borderless window (`.windowStyle(.plain)`).
@@ -118,6 +236,21 @@ struct CallView: View {
                 VStack {
                     participantNameBar
                     Spacer()
+                }
+
+                // Captions for the primary remote, pinned above the control
+                // bar so they don't crowd the PiP. Same CC styling as tiles.
+                if let firstRemote = viewModel.participants.first,
+                   let raw = viewModel.captions[firstRemote.id]?
+                       .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !raw.isEmpty {
+                    VStack {
+                        Spacer()
+                        captionStrip(wrapForCaptions(raw))
+                            .padding(.bottom, 92)
+                    }
+                    .transition(.opacity)
+                    .allowsHitTesting(false)
                 }
             }
 
@@ -301,6 +434,16 @@ struct CallView: View {
                 help: viewModel.isLocalCameraEnabled ? "Camera Off" : "Camera On"
             ) {
                 Task { try? await viewModel.toggleCamera() }
+            }
+
+            // Live captions toggle (on-device speech-to-text via SpeechAnalyzer)
+            controlButton(
+                icon: viewModel.isCaptionsEnabled ? "captions.bubble.fill" : "captions.bubble",
+                isActive: viewModel.isCaptionsEnabled,
+                help: viewModel.isCaptionsEnabled ? "Hide Captions" : "Show Captions"
+            ) {
+                let next = !viewModel.isCaptionsEnabled
+                Task { await viewModel.setCaptionsEnabled(next) }
             }
 
             // End call
@@ -603,6 +746,20 @@ private struct ParticipantTile: View {
 
             nameLabel
                 .padding(10)
+
+            // Live caption strip — only shown when captions are enabled and
+            // this participant has recent transcribed text. Sits above the
+            // name pill, centered horizontally. Uses the same shared
+            // CC-styled helper as the 1:1 layout.
+            if let raw = viewModel.captions[participant.id]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty {
+                captionStrip(wrapForCaptions(raw))
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 44)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .transition(.opacity)
+            }
         }
         // Tile sizes itself to the source video aspect, centered in the
         // grid cell. Surrounding cell area is transparent so the

--- a/RelayKit/Call/CallViewModel.swift
+++ b/RelayKit/Call/CallViewModel.swift
@@ -104,6 +104,89 @@ public final class CallViewModel: CallViewModelProtocol {
     /// Element Call's matrix-js-sdk `MatrixRTCSession` does the equivalent.
     @ObservationIgnored
     private var heartbeatTask: Task<Void, Never>?
+
+    // MARK: - Live Captions
+
+    public private(set) var isCaptionsEnabled: Bool = false
+    public private(set) var captions: [String: String] = [:]
+
+    /// Active caption transcribers keyed by participant identity. Created
+    /// lazily when captions are turned on or a remote audio track is
+    /// subscribed; torn down when captions are turned off, the participant
+    /// leaves, or the call ends.
+    @ObservationIgnored
+    private var captionTranscribers: [String: CaptionTranscriber] = [:]
+    /// The track sid each active transcriber is attached to, keyed by
+    /// participant identity. Lets attach/detach distinguish "same live track"
+    /// (a redundant attach) from "a different track for a reused identity"
+    /// (a leave→rejoin), so identity reuse is handled correctly regardless of
+    /// the order LiveKit delivers subscribe vs. unsubscribe/disconnect events.
+    @ObservationIgnored
+    private var captionTrackSids: [String: Track.Sid] = [:]
+
+    /// Per-participant rolling caption state. `history` accumulates
+    /// finalized utterances joined by spaces; `volatile` holds the
+    /// in-progress utterance the speaker is currently saying. The
+    /// display string is `history + " " + volatile`. New finals append
+    /// to history and clear volatile.
+    private struct CaptionState {
+        var history: String = ""
+        var volatile: String = ""
+
+        var displayText: String {
+            switch (history.isEmpty, volatile.isEmpty) {
+            case (true, true): return ""
+            case (true, false): return volatile
+            case (false, true): return history
+            case (false, false): return history + " " + volatile
+            }
+        }
+    }
+    @ObservationIgnored
+    private var captionStates: [String: CaptionState] = [:]
+
+    /// Per-participant idle fade timers. Reset on every caption update;
+    /// fires only when no new text has arrived for ``captionIdleFadeDelay``,
+    /// so long sentences stay on screen as they're being spoken AND for a
+    /// reasonable read-time after the speaker stops.
+    @ObservationIgnored
+    private var captionFadeTasks: [String: Task<Void, Never>] = [:]
+
+    /// Per-participant volatile-update debounce timers. Volatile partials
+    /// from `SpeechTranscriber` arrive every ~50–100 ms while a remote is
+    /// speaking, and many of them revise the just-shown text. Coalescing
+    /// rapid revisions into a single visual update inside a small window
+    /// trades a fraction of a second of latency for far less visible
+    /// "jumping" of in-progress text. Final results bypass this and apply
+    /// immediately — they're authoritative.
+    @ObservationIgnored
+    private var captionVolatileDebounceTasks: [String: Task<Void, Never>] = [:]
+    /// How long to wait before applying the latest volatile partial.
+    /// 180 ms is short enough that the displayed text never feels stale
+    /// to the speaker but long enough to absorb the typical rate of
+    /// recognizer revisions.
+    private static let captionVolatileDebounceDelay: Duration = .milliseconds(180)
+
+    /// Reading-rate target for the idle caption fade. Netflix's English
+    /// guideline is 17 characters per second for adult viewers; we round
+    /// to 17 and add a small buffer so the last word doesn't disappear
+    /// the instant the reader catches up. Used to size the fade delay
+    /// adaptively so a long sentence stays on screen long enough to
+    /// read while a single short word doesn't linger.
+    private static let captionReadCharsPerSecond: Double = 17
+    /// Floor for the idle fade — Netflix's minimum subtitle duration is
+    /// 5⁄6 of a second (833 ms). Anything shorter is too quick to perceive.
+    private static let captionMinHoldSeconds: Double = 5.0 / 6.0
+    /// Ceiling for the idle fade — Netflix's maximum subtitle duration is
+    /// 7 seconds. Beyond this the user has read the line and the screen
+    /// should clear, even if the buffer is unusually long.
+    private static let captionMaxHoldSeconds: Double = 7.0
+    /// Cap on the history string per participant — beyond this we drop
+    /// from the head, keeping only the most recent text. Sized for the
+    /// 42-char × 2-line Netflix wrap (84 chars visible) plus a buffer
+    /// so a recent-but-just-scrolled-off line is still in memory if a
+    /// volatile revision needs it.
+    private static let captionHistoryMaxChars: Int = 168
     /// Interval at which the call-member event is re-sent. Our `expires`
     /// field is 4 hours; refreshing every 30 minutes keeps a generous
     /// safety margin against missed sends.
@@ -549,6 +632,11 @@ public final class CallViewModel: CallViewModelProtocol {
         heartbeatTask?.cancel()
         heartbeatTask = nil
 
+        // Stop all captions before LiveKit unsubscribes the audio tracks
+        // from under us — the renderers must be removed first.
+        await stopAllCaptionTranscribers()
+        isCaptionsEnabled = false
+
         // Tear down the widget bridge synchronously so its tasks can't race
         // with subsequent connects.
         widgetBridge?.shutdown()
@@ -640,6 +728,229 @@ public final class CallViewModel: CallViewModelProtocol {
         let enabled = !isLocalMicrophoneEnabled
         try await room.localParticipant.setMicrophone(enabled: enabled)
         isLocalMicrophoneEnabled = enabled
+    }
+
+    // MARK: - Captions
+
+    public func setCaptionsEnabled(_ enabled: Bool) async {
+        guard enabled != isCaptionsEnabled else { return }
+        isCaptionsEnabled = enabled
+
+        if enabled {
+            // Attach to every currently-subscribed remote audio track. New
+            // tracks subscribed after this point are picked up via the
+            // didSubscribeTrack delegate callback.
+            for participant in room.remoteParticipants.values {
+                guard let identity = participant.identity?.stringValue else { continue }
+                for publication in participant.audioTracks {
+                    guard let track = publication.track as? RemoteAudioTrack else { continue }
+                    await attachCaptionTranscriber(to: track, identity: identity, trackSid: publication.sid)
+                }
+            }
+        } else {
+            await stopAllCaptionTranscribers()
+        }
+    }
+
+    /// Creates a `CaptionTranscriber` for `identity`, attaches it to `track`,
+    /// and starts the analyzer in the background.
+    ///
+    /// If a transcriber already exists for this identity: when it's bound to
+    /// the *same* track this is a redundant attach and is a no-op; when it's
+    /// bound to a *different* track — a leave→rejoin that reuses the identity —
+    /// the stale one is torn down first so the rejoined participant gets a
+    /// fresh, running transcriber. Without this, the rejoin would hit the old
+    /// early-return and get no captions.
+    private func attachCaptionTranscriber(to track: RemoteAudioTrack, identity: String, trackSid: Track.Sid) async {
+        if captionTranscribers[identity] != nil {
+            if captionTrackSids[identity] == trackSid { return }
+            await detachCaptionTranscriber(identity: identity)
+        }
+        let transcriber = CaptionTranscriber(
+            participantId: identity,
+            onUpdate: { [weak self] text, isFinal in
+                Task { @MainActor [weak self] in
+                    self?.applyCaption(participantId: identity, text: text, isFinal: isFinal)
+                }
+            },
+            onLog: { [weak self] severity, summary, detail in
+                Task { @MainActor [weak self] in
+                    self?.activityLog?.log(
+                        category: .call, severity: severity, source: "CaptionTranscriber",
+                        summary: summary, detail: detail, roomId: self?.roomID
+                    )
+                }
+            }
+        )
+        captionTranscribers[identity] = transcriber
+        captionTrackSids[identity] = trackSid
+        track.add(audioRenderer: transcriber)
+        Task {
+            do {
+                try await transcriber.start()
+            } catch {
+                activityLog?.log(
+                    category: .call, severity: .warning, source: "CallViewModel",
+                    summary: "Caption transcriber start failed",
+                    detail: "Identity: \(identity). Error: \(error.localizedDescription)",
+                    roomId: roomID
+                )
+            }
+        }
+    }
+
+    /// Detaches and stops the transcriber (if any) for `identity` from every
+    /// remote audio track that participant is publishing. Removes any cached
+    /// caption text and cancels the fade timer.
+    ///
+    /// When `ifTrackSid` is supplied, the detach only happens if the active
+    /// transcriber is bound to that track — so a late unsubscribe for an old
+    /// track can't tear down a transcriber that already belongs to a newer
+    /// track (a reused identity after a rejoin).
+    private func detachCaptionTranscriber(identity: String, ifTrackSid: Track.Sid? = nil) async {
+        if let ifTrackSid, captionTrackSids[identity] != ifTrackSid { return }
+        guard let transcriber = captionTranscribers.removeValue(forKey: identity) else { return }
+        captionTrackSids.removeValue(forKey: identity)
+        for participant in room.remoteParticipants.values where participant.identity?.stringValue == identity {
+            for publication in participant.audioTracks {
+                if let track = publication.track as? RemoteAudioTrack {
+                    track.remove(audioRenderer: transcriber)
+                }
+            }
+        }
+        await transcriber.stop()
+        captionFadeTasks.removeValue(forKey: identity)?.cancel()
+        captionVolatileDebounceTasks.removeValue(forKey: identity)?.cancel()
+        captionStates.removeValue(forKey: identity)
+        captions.removeValue(forKey: identity)
+    }
+
+    /// Tears down every active transcriber. Used by the captions toggle and
+    /// by `disconnect()`.
+    private func stopAllCaptionTranscribers() async {
+        let identities = Array(captionTranscribers.keys)
+        for identity in identities {
+            await detachCaptionTranscriber(identity: identity)
+        }
+        captionTrackSids.removeAll()
+        captions.removeAll()
+        captionStates.removeAll()
+        for task in captionFadeTasks.values { task.cancel() }
+        captionFadeTasks.removeAll()
+        for task in captionVolatileDebounceTasks.values { task.cancel() }
+        captionVolatileDebounceTasks.removeAll()
+    }
+
+    /// Tears down the transcriber for `identity` only if that participant is no
+    /// longer in the room. Used by `participantDidDisconnect` so a leave→rejoin
+    /// that reuses the identity doesn't tear down the freshly-attached
+    /// transcriber for the new session.
+    private func detachCaptionTranscriberIfGone(identity: String) async {
+        let stillPresent = room.remoteParticipants.values.contains {
+            $0.identity?.stringValue == identity
+        }
+        guard !stillPresent else { return }
+        await detachCaptionTranscriber(identity: identity)
+    }
+
+    /// Pushes a transcription update into the observable `captions` map. For
+    /// volatile (non-final) results the text is updated continuously; for
+    /// final results we additionally schedule a fade-out so a stale caption
+    /// doesn't linger after the speaker stops.
+    /// Entry point from `CaptionTranscriber`'s result stream. Debounces
+    /// volatile updates so the displayed text revises at most once per
+    /// debounce window; finals supersede pending volatiles and apply
+    /// immediately.
+    @MainActor
+    private func applyCaption(participantId: String, text: String, isFinal: Bool) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        // Any new event supersedes a pending debounced volatile.
+        captionVolatileDebounceTasks.removeValue(forKey: participantId)?.cancel()
+
+        if isFinal {
+            commitCaption(participantId: participantId, text: trimmed, isFinal: true)
+            return
+        }
+
+        // Volatile — schedule a debounced commit. Subsequent volatile
+        // updates within the window cancel and replace this one, so the
+        // UI only sees the *latest* partial after the recognizer has
+        // settled for at least the debounce delay.
+        let delay = Self.captionVolatileDebounceDelay
+        let task = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            if Task.isCancelled { return }
+            await MainActor.run {
+                guard let self else { return }
+                self.captionVolatileDebounceTasks.removeValue(forKey: participantId)
+                self.commitCaption(participantId: participantId, text: trimmed, isFinal: false)
+            }
+        }
+        captionVolatileDebounceTasks[participantId] = task
+    }
+
+    /// Applies a caption update to the rolling buffer + observable state.
+    /// Called either directly (for finals) or via the debounce timer (for
+    /// volatiles). Same logic that used to live inline in `applyCaption`.
+    @MainActor
+    private func commitCaption(participantId: String, text: String, isFinal: Bool) {
+        let trimmed = text
+
+        // Speech content stays out of the log — record only the metadata so we
+        // can verify the audio→speech pipeline without leaking captions.
+        activityLog?.log(
+            category: .call, severity: .debug, source: "CallViewModel",
+            summary: "Caption update",
+            detail: "Identity: \(participantId), isFinal: \(isFinal), chars: \(trimmed.count)",
+            roomId: roomID
+        )
+
+        // Rolling-buffer model:
+        // - Volatile result → replace `volatile`. The same utterance keeps
+        //   being revised in place as the speaker continues.
+        // - Final result → append to `history` (with a space separator)
+        //   and clear `volatile` to make room for the next utterance.
+        // - Cap history from the head so it can't grow unbounded.
+        var state = captionStates[participantId] ?? CaptionState()
+        if isFinal {
+            if state.history.isEmpty {
+                state.history = trimmed
+            } else {
+                state.history += " " + trimmed
+            }
+            if state.history.count > Self.captionHistoryMaxChars {
+                state.history = String(state.history.suffix(Self.captionHistoryMaxChars))
+            }
+            state.volatile = ""
+        } else {
+            state.volatile = trimmed
+        }
+        captionStates[participantId] = state
+        captions[participantId] = state.displayText
+
+        // Idle-based fade with Netflix-style reading-rate scaling. Reset
+        // on every update (volatile OR final). The hold time after the
+        // speaker stops scales with how much text is on screen — a single
+        // short word clears in ~1s, a packed 2-line block stays for ~5s,
+        // and we never go below 5⁄6s or above 7s.
+        captionFadeTasks[participantId]?.cancel()
+        let displayChars = Double(state.displayText.count)
+        let readSeconds = displayChars / Self.captionReadCharsPerSecond
+        let holdSeconds = min(Self.captionMaxHoldSeconds,
+                              max(Self.captionMinHoldSeconds, readSeconds))
+        let delay = Duration.seconds(holdSeconds)
+        captionFadeTasks[participantId] = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            if Task.isCancelled { return }
+            await MainActor.run {
+                guard let self else { return }
+                self.captions.removeValue(forKey: participantId)
+                self.captionStates.removeValue(forKey: participantId)
+                self.captionFadeTasks.removeValue(forKey: participantId)
+            }
+        }
     }
 
     public func videoAspectRatio(for participantID: String) -> CGFloat? {
@@ -1038,6 +1349,12 @@ public final class CallViewModel: CallViewModelProtocol {
                     roomId: viewModel.roomID
                 )
                 viewModel.syncParticipants(trackChanged: true)
+                // Wire captions onto any new remote audio if captions are on.
+                if viewModel.isCaptionsEnabled,
+                   let identity = participant.identity?.stringValue,
+                   let track = publication.track as? RemoteAudioTrack {
+                    await viewModel.attachCaptionTranscriber(to: track, identity: identity, trackSid: publication.sid)
+                }
             }
         }
 
@@ -1069,6 +1386,13 @@ public final class CallViewModel: CallViewModelProtocol {
                     detail: "Identity: \(identityStr)",
                     roomId: viewModel.roomID
                 )
+                // Tear down captions in case didUnsubscribeTrack didn't fire
+                // for this participant's audio on disconnect — but only if the
+                // participant is actually gone, so a quick leave→rejoin that
+                // reuses the identity doesn't kill the new session's captions.
+                if let identity = participant.identity?.stringValue {
+                    await viewModel.detachCaptionTranscriberIfGone(identity: identity)
+                }
                 viewModel.syncParticipants(trackChanged: true)
             }
         }
@@ -1179,9 +1503,16 @@ public final class CallViewModel: CallViewModelProtocol {
 
         func room(_ room: LiveKit.Room, participant: RemoteParticipant, didUnsubscribeTrack publication: RemoteTrackPublication) {
             Task { @MainActor [weak viewModel] in
-                viewModel?.syncParticipants(trackChanged: true)
+                guard let viewModel else { return }
+                viewModel.syncParticipants(trackChanged: true)
+                // Tear down captions for this specific audio track if it had any.
+                if let identity = participant.identity?.stringValue,
+                   publication.kind == .audio {
+                    await viewModel.detachCaptionTranscriber(identity: identity, ifTrackSid: publication.sid)
+                }
             }
         }
+
 
         func room(_ room: LiveKit.Room, participant: LocalParticipant, didUnpublishTrack publication: LocalTrackPublication) {
             Task { @MainActor [weak viewModel] in

--- a/RelayKit/Call/CaptionTranscriber.swift
+++ b/RelayKit/Call/CaptionTranscriber.swift
@@ -1,0 +1,294 @@
+// Copyright 2026 Link Dupont
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AVFoundation
+import Foundation
+import LiveKit
+import os
+import RelayInterface
+import Speech
+
+/// Type-eraser that lets us hand a non-Sendable `AVAudioPCMBuffer` to
+/// `AVAudioConverter.convert`'s `@Sendable` input closure. Safe here
+/// because the converter consumes the buffer synchronously inside the call;
+/// we never share the box across concurrency domains.
+nonisolated private final class _BufferBox: @unchecked Sendable {
+    let buffer: AVAudioPCMBuffer
+    init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+}
+
+/// Wraps Apple's on-device `SpeechAnalyzer` + `SpeechTranscriber` (macOS 26+)
+/// behind LiveKit's ``AudioRenderer`` so a single instance can be attached to a
+/// `RemoteAudioTrack` and turn its audio into a stream of partial / final
+/// captions.
+///
+/// Lifecycle:
+///
+/// 1. Create with the participant's ID and a `@Sendable` callback.
+/// 2. `start()` — installs the locale model if needed, kicks off the analyzer,
+///    and spins up a task draining `transcriber.results` into the callback.
+/// 3. Attach to the audio track via `track.add(audioRenderer:)`. Each
+///    `render(pcmBuffer:)` is converted to the analyzer's preferred format and
+///    yielded into the input stream.
+/// 4. `stop()` — cancels the result task, finalizes the analyzer, and tears
+///    down the converter.
+///
+/// All speech recognition is on-device; the model is downloaded via
+/// `AssetInventory` on first use and managed by the system from then on.
+final class CaptionTranscriber: NSObject, AudioRenderer, @unchecked Sendable {
+
+    /// Stable identifier of the participant whose audio we're transcribing —
+    /// used by the callback to route updates back to the correct UI tile.
+    let participantId: String
+
+    /// Receives caption updates. `text` is the latest transcription (volatile
+    /// or final); `isFinal == true` means the analyzer has committed it.
+    private let onUpdate: @Sendable (_ text: String, _ isFinal: Bool) -> Void
+
+    /// Emits a diagnostic event to the call's activity log. Injected by the
+    /// owner (`CallViewModel`) so this background/render-thread component never
+    /// has to touch the `@MainActor`-isolated `ActivityLog` directly — the
+    /// closure does the actor hop. No speech content is ever passed, only
+    /// metadata.
+    typealias LogEmit = @Sendable (_ severity: ActivityEvent.Severity, _ summary: String, _ detail: String?) -> Void
+    private let onLog: LogEmit
+
+    /// The locale used to pick a transcriber. Defaults to `Locale.current` —
+    /// captions are *for* the local user, so their preferred locale wins.
+    private let locale: Locale
+
+    // Speech components — created in `start()`, torn down in `stop()`.
+    private var transcriber: SpeechTranscriber?
+    private var analyzer: SpeechAnalyzer?
+    private var resultsTask: Task<Void, Never>?
+
+    /// Mutable state touched from both the audio render thread and the
+    /// owner. Held under an unfair lock so `render(pcmBuffer:)` stays
+    /// synchronous and doesn't pay an actor-hop per buffer.
+    private struct State {
+        var inputBuilder: AsyncStream<AnalyzerInput>.Continuation?
+        var converter: AVAudioConverter?
+        var converterSource: AVAudioFormat?
+        var converterTarget: AVAudioFormat?
+        var stopped: Bool = false
+        // Diagnostic counters — used to log a one-shot "first frame
+        // delivered" message and to surface drop reasons. Reset on stop.
+        var totalRendered: Int = 0
+        var droppedNotReady: Int = 0
+        var droppedConversionFailed: Int = 0
+        var totalYielded: Int = 0
+        var didLogFirstYield: Bool = false
+    }
+    private let state = OSAllocatedUnfairLock<State>(initialState: State())
+
+    init(
+        participantId: String,
+        locale: Locale = .current,
+        onUpdate: @escaping @Sendable (String, Bool) -> Void,
+        onLog: @escaping LogEmit
+    ) {
+        self.participantId = participantId
+        self.locale = locale
+        self.onUpdate = onUpdate
+        self.onLog = onLog
+        super.init()
+    }
+
+    /// Installs the locale model if needed, starts the analyzer, and begins
+    /// draining results. Errors propagate so the caller can log + skip
+    /// transcribing this track.
+    func start() async throws {
+        // Use the progressive preset — Apple's tuned configuration for
+        // streaming live captioning. Layer on `.fastResults` (less LM
+        // verification, lower latency) and `.volatileResults` (per-syllable
+        // partials so the UI updates continuously instead of in
+        // sentence-sized chunks). For live captions, freshness is worth
+        // the modest accuracy trade-off; the user gets context from the
+        // rolling history.
+        var preset = SpeechTranscriber.Preset.progressiveTranscription
+        preset.reportingOptions.insert(.volatileResults)
+        preset.reportingOptions.insert(.fastResults)
+        let transcriber = SpeechTranscriber(locale: locale, preset: preset)
+
+        try await Self.ensureModelInstalled(for: transcriber, onLog: onLog)
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let target = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [transcriber]
+        )
+
+        let (input, builder) = AsyncStream<AnalyzerInput>.makeStream()
+        try await analyzer.start(inputSequence: input)
+
+        self.transcriber = transcriber
+        self.analyzer = analyzer
+        state.withLock {
+            $0.inputBuilder = builder
+            $0.converterTarget = target
+        }
+
+        // Drain results in a long-lived task. AttributedString is converted to
+        // plain string before the @Sendable callback to keep the call site
+        // free of UI imports.
+        let pid = participantId
+        let cb = onUpdate
+        resultsTask = Task {
+            var loggedFirst = false
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    if !loggedFirst {
+                        loggedFirst = true
+                        onLog(.debug, "Caption first result", "Identity: \(pid), chars: \(text.count), isFinal: \(result.isFinal)")
+                    }
+                    cb(text, result.isFinal)
+                }
+                onLog(.debug, "Caption results stream ended", "Identity: \(pid)")
+            } catch is CancellationError {
+                // Expected on stop(); silent.
+            } catch {
+                onLog(.warning, "Caption results stream failed", "Identity: \(pid). Error: \(error.localizedDescription)")
+            }
+        }
+
+        let formatDesc = target.map { "\($0.sampleRate)Hz \($0.channelCount)ch" } ?? "nil"
+        onLog(.info, "Caption transcriber started", "Identity: \(pid), locale: \(self.locale.identifier), target: \(formatDesc)")
+    }
+
+    /// Tears the analyzer down. Safe to call multiple times.
+    func stop() async {
+        let builder = state.withLock { s -> AsyncStream<AnalyzerInput>.Continuation? in
+            guard !s.stopped else { return nil }
+            s.stopped = true
+            let b = s.inputBuilder
+            s.inputBuilder = nil
+            s.converter = nil
+            s.converterSource = nil
+            s.converterTarget = nil
+            return b
+        }
+        builder?.finish()
+        try? await analyzer?.finalizeAndFinishThroughEndOfInput()
+        resultsTask?.cancel()
+        resultsTask = nil
+        analyzer = nil
+        transcriber = nil
+        onLog(.info, "Caption transcriber stopped", "Identity: \(self.participantId)")
+    }
+
+    // MARK: - AudioRenderer
+
+    /// Called by LiveKit on the audio thread for every PCM buffer that's
+    /// about to be played for this remote track. Buffers are post-decryption.
+    func render(pcmBuffer: AVAudioPCMBuffer) {
+        // Wrap the non-Sendable pcmBuffer in a Sendable box BEFORE entering
+        // the lock — `OSAllocatedUnfairLock.withLock`'s body is @Sendable,
+        // and the conversion closure inside it is @Sendable too. The box
+        // is the only thing safe to capture across both boundaries.
+        let inputBox = _BufferBox(pcmBuffer)
+        let inputFormat = pcmBuffer.format
+        let inputFrameCount = pcmBuffer.frameLength
+        let pid = participantId
+
+        // Each render returns a small status report so we can log outside
+        // the lock without doing I/O on the audio thread under the lock.
+        enum Outcome {
+            case notReady
+            case conversionFailed(String?)
+            case yielded(firstTime: Bool, frames: Int)
+        }
+
+        let outcome: Outcome = state.withLock { s in
+            s.totalRendered += 1
+            guard !s.stopped,
+                  let target = s.converterTarget,
+                  let builder = s.inputBuilder else {
+                s.droppedNotReady += 1
+                return .notReady
+            }
+
+            // Build / refresh the converter on first buffer or when the
+            // upstream format changes. AVAudioConverter is reusable across
+            // calls but tied to a single source/target pair.
+            if s.converter == nil || s.converterSource != inputFormat {
+                s.converter = AVAudioConverter(from: inputFormat, to: target)
+                s.converterSource = inputFormat
+            }
+            guard let converter = s.converter else {
+                s.droppedConversionFailed += 1
+                return .conversionFailed("no converter")
+            }
+
+            // Sample-rate ratio + a little slack for resampler tail.
+            let ratio = target.sampleRate / inputFormat.sampleRate
+            let cap = AVAudioFrameCount(Double(inputFrameCount) * ratio + 1024)
+            guard let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: cap) else {
+                s.droppedConversionFailed += 1
+                return .conversionFailed("alloc")
+            }
+
+            var error: NSError?
+            nonisolated(unsafe) var consumed = false
+            _ = converter.convert(to: out, error: &error) { _, status in
+                if consumed {
+                    // .noDataNow — NOT .endOfStream. With .endOfStream the
+                    // converter flushes and enters a finished state that
+                    // permanently refuses subsequent input, so every render()
+                    // after the first returns 0 frames. .noDataNow tells the
+                    // converter "this batch is done, but more is coming".
+                    status.pointee = .noDataNow
+                    return nil
+                }
+                consumed = true
+                status.pointee = .haveData
+                return inputBox.buffer
+            }
+            if error != nil || out.frameLength == 0 {
+                s.droppedConversionFailed += 1
+                return .conversionFailed(error?.localizedDescription ?? "empty out")
+            }
+
+            builder.yield(AnalyzerInput(buffer: out))
+            s.totalYielded += 1
+            let firstTime = !s.didLogFirstYield
+            if firstTime { s.didLogFirstYield = true }
+            return .yielded(firstTime: firstTime, frames: Int(out.frameLength))
+        }
+
+        switch outcome {
+        case .notReady:
+            // Silent: this is expected for the first ~few frames before
+            // start() finishes setting `inputBuilder`.
+            break
+        case .conversionFailed(let reason):
+            onLog(.warning, "Caption conversion failed", "Identity: \(pid). Reason: \(reason ?? "?")")
+        case .yielded(let firstTime, let frames):
+            if firstTime {
+                onLog(.debug, "Caption first audio frame yielded", "Identity: \(pid), frames: \(frames)")
+            }
+        }
+    }
+
+    // MARK: - Asset Management
+
+    /// Installs the locale model for the given transcriber if it isn't already
+    /// available. First-time install can take several seconds; subsequent
+    /// calls are immediate.
+    private static func ensureModelInstalled(for transcriber: SpeechTranscriber, onLog: LogEmit) async throws {
+        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            onLog(.info, "Downloading captions model", nil)
+            try await request.downloadAndInstall()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in live captions to MatrixRTC calls. Each remote participant's
audio is transcribed on-device with Apple's `SpeechAnalyzer` /
`SpeechTranscriber` (macOS 26+) and the text is rendered over their video.
Nothing leaves the device — the locale model is fetched via `AssetInventory`
on first use.

## How it works

- **`CaptionTranscriber`** (new) implements LiveKit's `AudioRenderer`. It
  drives one `SpeechTranscriber` (`.progressiveTranscription` +
  `.volatileResults`) and feeds it audio converted to the analyzer's
  preferred format via a cached `AVAudioConverter`.
- **`CallViewModel`** attaches a transcriber per remote audio track, keyed by
  (identity, track sid). The full lifecycle is covered: already-present
  participants on toggle (`setCaptionsEnabled`), late joiners via
  `didSubscribeTrack`, and teardown via `didUnsubscribeTrack`,
  `participantDidDisconnect`, and call `disconnect()`. Sid-keying makes a
  leave→rejoin that reuses an identity attach a fresh transcriber regardless
  of the order subscribe/unsubscribe events arrive.
- Per-participant state is a rolling `history` + `volatile` buffer. Volatile
  partials are debounced (180 ms) so the recognizer's rapid mid-utterance
  revisions don't make on-screen words jump; finals apply immediately. Idle
  fade scales with reading rate (`clamp(chars/17, 5⁄6s, 7s)`).

## UI

- New toggle (`captions.bubble.fill`) on the call control pill, between the
  camera and end-call buttons.
- Caption strip: white `.title3`-semibold on a near-opaque rounded rect,
  ≤2 lines, Netflix-style 42-char word-aware wrapping. Renders on each tile
  in the group grid and under the primary video in 1:1.

## Privacy

Speech content is never logged — diagnostics emit metadata only.

## Requirements

macOS 26 (Tahoe)+ — `SpeechAnalyzer`/`SpeechTranscriber` are 26-only.

## Testing

- 1:1 and group calls; captions toggled on before and during a call.
- Participant joining mid-call (transcriber attaches), leaving (tears down),
  and leave→rejoin (captions return on the second join).
- Verified on-device; no caption text in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)