### PR TITLE
Add camera input selection to the call window

### DIFF
--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
@@ -80,6 +80,23 @@ public struct CameraDevice: Identifiable, Sendable, Equatable {
     }
 }
 
+/// A selectable audio input (microphone) known to the system.
+///
+/// Like ``CameraDevice``, a plain value type so the call UI can list and pick
+/// inputs without depending on the audio SDK; `CallViewModel` maps these
+/// to/from the LiveKit audio device by ``id``.
+public struct AudioInputDevice: Identifiable, Sendable, Equatable {
+    /// The system audio device id (LiveKit `AudioDevice.deviceId`).
+    public let id: String
+    /// Human-readable name for the menu.
+    public let name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
 /// The view model protocol for a LiveKit-backed audio/video call in a Matrix room.
 ///
 /// ``CallViewModelProtocol`` defines the observable state and actions needed by ``CallView``
@@ -146,6 +163,19 @@ public protocol CallViewModelProtocol: AnyObject, Observable {
     /// Switches the local camera input to `device`. Applies live when the
     /// camera is on; otherwise it's remembered and used on the next enable.
     func selectCamera(_ device: CameraDevice) async throws
+
+    /// Microphone inputs currently available to the system, for the picker.
+    var availableAudioInputs: [AudioInputDevice] { get }
+
+    /// The `id` of the audio input currently in use, or `nil` before one is
+    /// resolved.
+    var selectedAudioInputID: String? { get }
+
+    /// Re-enumerates the system's audio inputs into ``availableAudioInputs``.
+    func refreshAudioInputs() async
+
+    /// Switches the active microphone input to `device`.
+    func selectAudioInput(_ device: AudioInputDevice) async throws
 
     /// Toggles the local microphone on or off.
     func toggleMicrophone() async throws

--- a/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
+++ b/Packages/RelayInterface/Sources/RelayInterface/Protocols/CallViewModelProtocol.swift
@@ -57,6 +57,29 @@ public struct CallParticipant: Identifiable, Sendable, Equatable {
     }
 }
 
+/// A selectable camera input known to the system (built-in, external/USB, or
+/// an iPhone via Continuity Camera).
+///
+/// Intentionally a plain value type so the call UI can list and pick cameras
+/// without depending on AVFoundation or LiveKit — `CallViewModel` maps these
+/// to/from `AVCaptureDevice` by ``id`` inside RelayKit.
+public struct CameraDevice: Identifiable, Sendable, Equatable {
+    /// The system's stable `AVCaptureDevice.uniqueID`.
+    public let id: String
+    /// Human-readable name for the menu (the device's `localizedName`).
+    public let name: String
+    /// Coarse category, used only to pick an icon in the picker.
+    public let kind: Kind
+
+    public enum Kind: Sendable, Equatable { case builtIn, external, continuity, unknown }
+
+    public init(id: String, name: String, kind: Kind) {
+        self.id = id
+        self.name = name
+        self.kind = kind
+    }
+}
+
 /// The view model protocol for a LiveKit-backed audio/video call in a Matrix room.
 ///
 /// ``CallViewModelProtocol`` defines the observable state and actions needed by ``CallView``
@@ -107,6 +130,22 @@ public protocol CallViewModelProtocol: AnyObject, Observable {
 
     /// Toggles the local camera on or off.
     func toggleCamera() async throws
+
+    /// Camera inputs currently available to the system, for the picker.
+    /// Refreshed via ``refreshCameras()``.
+    var availableCameras: [CameraDevice] { get }
+
+    /// The `id` of the camera currently in use, or `nil` before one is chosen.
+    var selectedCameraID: String? { get }
+
+    /// Re-enumerates the system's cameras into ``availableCameras``. Cheap to
+    /// call when opening the picker (covers a Continuity Camera connecting
+    /// mid-call).
+    func refreshCameras() async
+
+    /// Switches the local camera input to `device`. Applies live when the
+    /// camera is on; otherwise it's remembered and used on the next enable.
+    func selectCamera(_ device: CameraDevice) async throws
 
     /// Toggles the local microphone on or off.
     func toggleMicrophone() async throws

--- a/Relay/ViewModels/PreviewCallViewModel.swift
+++ b/Relay/ViewModels/PreviewCallViewModel.swift
@@ -35,6 +35,11 @@ final class PreviewCallViewModel: CallViewModelProtocol {
         CameraDevice(id: "iphone", name: "iPhone (Continuity)", kind: .continuity)
     ]
     var selectedCameraID: String? = "builtin"
+    var availableAudioInputs: [AudioInputDevice] = [
+        AudioInputDevice(id: "builtin-mic", name: "MacBook Pro Microphone"),
+        AudioInputDevice(id: "usb-mic", name: "USB Audio Interface")
+    ]
+    var selectedAudioInputID: String? = "builtin-mic"
 
     func connect(url: String, token: String, sfuServiceURL: String) async throws {
         state = .connecting
@@ -81,6 +86,12 @@ final class PreviewCallViewModel: CallViewModelProtocol {
 
     func selectCamera(_ device: CameraDevice) async throws {
         selectedCameraID = device.id
+    }
+
+    func refreshAudioInputs() async {}
+
+    func selectAudioInput(_ device: AudioInputDevice) async throws {
+        selectedAudioInputID = device.id
     }
 
     func makeVideoView(for participantID: String) -> AnyView? { nil }

--- a/Relay/ViewModels/PreviewCallViewModel.swift
+++ b/Relay/ViewModels/PreviewCallViewModel.swift
@@ -30,6 +30,11 @@ final class PreviewCallViewModel: CallViewModelProtocol {
     var localParticipantID: String? = nil
     var videoTrackRevision: UInt = 0
     var connectingPhase: String? = nil
+    var availableCameras: [CameraDevice] = [
+        CameraDevice(id: "builtin", name: "FaceTime HD Camera", kind: .builtIn),
+        CameraDevice(id: "iphone", name: "iPhone (Continuity)", kind: .continuity)
+    ]
+    var selectedCameraID: String? = "builtin"
 
     func connect(url: String, token: String, sfuServiceURL: String) async throws {
         state = .connecting
@@ -70,6 +75,12 @@ final class PreviewCallViewModel: CallViewModelProtocol {
 
     func toggleMicrophone() async throws {
         isLocalMicrophoneEnabled.toggle()
+    }
+
+    func refreshCameras() async {}
+
+    func selectCamera(_ device: CameraDevice) async throws {
+        selectedCameraID = device.id
     }
 
     func makeVideoView(for participantID: String) -> AnyView? { nil }

--- a/Relay/Views/Call/CallView.swift
+++ b/Relay/Views/Call/CallView.swift
@@ -285,13 +285,18 @@ struct CallView: View {
     @ViewBuilder
     private var controlBar: some View {
         HStack(spacing: 20) {
-            // Microphone toggle
-            controlButton(
-                icon: viewModel.isLocalMicrophoneEnabled ? "mic.fill" : "mic.slash.fill",
-                isActive: viewModel.isLocalMicrophoneEnabled,
-                help: viewModel.isLocalMicrophoneEnabled ? "Mute" : "Unmute"
-            ) {
-                Task { try? await viewModel.toggleMicrophone() }
+            // Microphone: split control (toggle + source menu) when more than
+            // one input is available, otherwise a plain toggle.
+            if viewModel.availableAudioInputs.count > 1 {
+                micSplitControl
+            } else {
+                controlButton(
+                    icon: viewModel.isLocalMicrophoneEnabled ? "mic.fill" : "mic.slash.fill",
+                    isActive: viewModel.isLocalMicrophoneEnabled,
+                    help: viewModel.isLocalMicrophoneEnabled ? "Mute" : "Unmute"
+                ) {
+                    Task { try? await viewModel.toggleMicrophone() }
+                }
             }
 
             // Camera: split control (toggle + source menu) when more than one
@@ -397,6 +402,65 @@ struct CallView: View {
         case .external: return "web.camera"
         case .builtIn, .unknown: return "camera"
         }
+    }
+
+    /// Mic equivalent of ``cameraSplitControl``: the mute toggle plus a
+    /// disclosure menu of audio inputs. Used when more than one input exists.
+    private var micSplitControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                Task { try? await viewModel.toggleMicrophone() }
+            } label: {
+                Image(systemName: viewModel.isLocalMicrophoneEnabled ? "mic.fill" : "mic.slash.fill")
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(viewModel.isLocalMicrophoneEnabled ? "Mute" : "Unmute")
+
+            Rectangle()
+                .fill(Color.white.opacity(0.25))
+                .frame(width: 1, height: 22)
+
+            Menu {
+                Picker("Microphone", selection: audioInputSelectionBinding) {
+                    ForEach(viewModel.availableAudioInputs) { input in
+                        Label(input.name, systemImage: "mic")
+                            .tag(input.id as String?)
+                    }
+                }
+                .pickerStyle(.inline)
+                .onAppear { Task { await viewModel.refreshAudioInputs() } }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 34, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Microphone Source")
+        }
+        .background(
+            viewModel.isLocalMicrophoneEnabled ? Color.white.opacity(0.15) : Color.red.opacity(0.8),
+            in: Capsule()
+        )
+    }
+
+    private var audioInputSelectionBinding: Binding<String?> {
+        Binding(
+            get: { viewModel.selectedAudioInputID },
+            set: { newID in
+                guard let newID,
+                      let input = viewModel.availableAudioInputs.first(where: { $0.id == newID })
+                else { return }
+                Task { try? await viewModel.selectAudioInput(input) }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Relay/Views/Call/CallView.swift
+++ b/Relay/Views/Call/CallView.swift
@@ -294,13 +294,18 @@ struct CallView: View {
                 Task { try? await viewModel.toggleMicrophone() }
             }
 
-            // Camera toggle
-            controlButton(
-                icon: viewModel.isLocalCameraEnabled ? "video.fill" : "video.slash.fill",
-                isActive: viewModel.isLocalCameraEnabled,
-                help: viewModel.isLocalCameraEnabled ? "Camera Off" : "Camera On"
-            ) {
-                Task { try? await viewModel.toggleCamera() }
+            // Camera: split control (toggle + source menu) when more than one
+            // camera is available, otherwise a plain toggle.
+            if viewModel.availableCameras.count > 1 {
+                cameraSplitControl
+            } else {
+                controlButton(
+                    icon: viewModel.isLocalCameraEnabled ? "video.fill" : "video.slash.fill",
+                    isActive: viewModel.isLocalCameraEnabled,
+                    help: viewModel.isLocalCameraEnabled ? "Camera Off" : "Camera On"
+                ) {
+                    Task { try? await viewModel.toggleCamera() }
+                }
             }
 
             // End call
@@ -321,6 +326,77 @@ struct CallView: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 12)
         .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    /// A split control: the camera on/off toggle on the left and a disclosure
+    /// caret on the right that opens the camera-source menu — one capsule,
+    /// sharing the on/off tint. Used when more than one camera is available.
+    /// The menu refreshes the device list each time it opens so a camera
+    /// connected mid-call (e.g. an iPhone via Continuity) shows up.
+    private var cameraSplitControl: some View {
+        HStack(spacing: 0) {
+            Button {
+                Task { try? await viewModel.toggleCamera() }
+            } label: {
+                Image(systemName: viewModel.isLocalCameraEnabled ? "video.fill" : "video.slash.fill")
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(viewModel.isLocalCameraEnabled ? "Camera Off" : "Camera On")
+
+            Rectangle()
+                .fill(Color.white.opacity(0.25))
+                .frame(width: 1, height: 22)
+
+            Menu {
+                Picker("Camera", selection: cameraSelectionBinding) {
+                    ForEach(viewModel.availableCameras) { camera in
+                        Label(camera.name, systemImage: Self.cameraIcon(for: camera.kind))
+                            .tag(camera.id as String?)
+                    }
+                }
+                .pickerStyle(.inline)
+                .onAppear { Task { await viewModel.refreshCameras() } }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 34, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Camera Source")
+        }
+        .background(
+            viewModel.isLocalCameraEnabled ? Color.white.opacity(0.15) : Color.red.opacity(0.8),
+            in: Capsule()
+        )
+    }
+
+    /// Bridges the picker's selected id to `selectCamera`.
+    private var cameraSelectionBinding: Binding<String?> {
+        Binding(
+            get: { viewModel.selectedCameraID },
+            set: { newID in
+                guard let newID,
+                      let camera = viewModel.availableCameras.first(where: { $0.id == newID })
+                else { return }
+                Task { try? await viewModel.selectCamera(camera) }
+            }
+        )
+    }
+
+    private static func cameraIcon(for kind: CameraDevice.Kind) -> String {
+        switch kind {
+        case .continuity: return "iphone"
+        case .external: return "web.camera"
+        case .builtIn, .unknown: return "camera"
+        }
     }
 
     @ViewBuilder

--- a/RelayKit/Call/CallViewModel.swift
+++ b/RelayKit/Call/CallViewModel.swift
@@ -50,6 +50,11 @@ public final class CallViewModel: CallViewModelProtocol {
     /// resolved.
     public private(set) var selectedCameraID: String?
 
+    /// Microphone inputs available to the system, for the in-call picker.
+    public private(set) var availableAudioInputs: [AudioInputDevice] = []
+    /// The deviceId of the audio input currently in use.
+    public private(set) var selectedAudioInputID: String?
+
     @ObservationIgnored
     private let room = LiveKit.Room()
     @ObservationIgnored
@@ -79,6 +84,15 @@ public final class CallViewModel: CallViewModelProtocol {
     /// UserDefaults key for the last-used camera, preferred on the next call.
     @ObservationIgnored
     private let selectedCameraDefaultsKey = "selectedCameraUniqueID"
+
+    /// Maps `AudioInputDevice.id` (deviceId) to the SDK audio device so
+    /// `selectAudioInput` can resolve a picked entry. Audio input selection is
+    /// process-global via `AudioManager.shared`, not per-call.
+    @ObservationIgnored
+    private var audioInputsByID: [String: AudioDevice] = [:]
+    /// UserDefaults key for the last-used microphone, preferred on the next call.
+    @ObservationIgnored
+    private let selectedAudioInputDefaultsKey = "selectedAudioInputDeviceID"
 
     // MARK: - E2EE State
     //
@@ -492,6 +506,13 @@ public final class CallViewModel: CallViewModelProtocol {
                cameraDevicesByID[saved] != nil {
                 selectedCameraID = saved
             }
+            await refreshAudioInputs()
+            // Prefer the last-used microphone if it's still present.
+            if let savedAudio = UserDefaults.standard.string(forKey: selectedAudioInputDefaultsKey),
+               let device = audioInputsByID[savedAudio] {
+                AudioManager.shared.inputDevice = device
+                selectedAudioInputID = savedAudio
+            }
             try await room.localParticipant.setMicrophone(enabled: true)
             try await room.localParticipant.setCamera(enabled: true, captureOptions: selectedCameraCaptureOptions())
             // Reflect whichever device actually started so the picker checkmark
@@ -736,6 +757,58 @@ public final class CallViewModel: CallViewModelProtocol {
         case .external: return .external
         default: return .unknown
         }
+    }
+
+    public func refreshAudioInputs() async {
+        let devices = AudioManager.shared.inputDevices
+        var byID: [String: AudioDevice] = [:]
+        var list: [AudioInputDevice] = []
+        var indexByName: [String: Int] = [:]
+        for device in devices {
+            byID[device.deviceId] = device
+            if let idx = indexByName[device.name] {
+                // Bluetooth inputs like AirPods register several CoreAudio
+                // device objects under one name. Collapse them to a single
+                // entry (matching System Settings); prefer the default
+                // object's id as the representative so selecting it routes
+                // correctly.
+                if device.isDefault {
+                    list[idx] = AudioInputDevice(id: device.deviceId, name: device.name)
+                }
+            } else {
+                indexByName[device.name] = list.count
+                list.append(AudioInputDevice(id: device.deviceId, name: device.name))
+            }
+        }
+        audioInputsByID = byID
+        availableAudioInputs = list
+        // Reflect the active device as its deduped (by-name) representative so
+        // the checkmark matches a list entry even when the live id was one of
+        // the collapsed duplicates.
+        let currentName = AudioManager.shared.inputDevice.name
+        selectedAudioInputID = list.first(where: { $0.name == currentName })?.id
+    }
+
+    public func selectAudioInput(_ device: AudioInputDevice) async throws {
+        // Update the UI immediately, then do the actual switch off the main
+        // actor: LiveKit's AudioManager retargets the audio device module
+        // synchronously, which on Bluetooth rebuilds the whole engine and can
+        // block for seconds. Only the deviceId (Sendable) crosses the
+        // boundary — AudioDevice is a non-Sendable class.
+        selectedAudioInputID = device.id
+        UserDefaults.standard.set(device.id, forKey: selectedAudioInputDefaultsKey)
+        let deviceId = device.id
+        await Task.detached(priority: .userInitiated) {
+            guard let avDevice = AudioManager.shared.inputDevices
+                .first(where: { $0.deviceId == deviceId }) else { return }
+            AudioManager.shared.inputDevice = avDevice
+        }.value
+        activityLog?.log(
+            category: .call, severity: .info, source: "CallViewModel",
+            summary: "Audio input selected",
+            detail: "Microphone: \(device.name)",
+            roomId: roomID
+        )
     }
 
     public func toggleMicrophone() async throws {

--- a/RelayKit/Call/CallViewModel.swift
+++ b/RelayKit/Call/CallViewModel.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import AVFoundation
 import Foundation
 import LiveKit
 import RelayInterface
@@ -43,6 +44,12 @@ public final class CallViewModel: CallViewModelProtocol {
     /// re-evaluate `videoContent(for:)` and pick up new or removed tracks.
     public private(set) var videoTrackRevision: UInt = 0
 
+    /// Camera inputs available to the system, for the in-call picker.
+    public private(set) var availableCameras: [CameraDevice] = []
+    /// The `uniqueID` of the camera currently in use, or `nil` before one is
+    /// resolved.
+    public private(set) var selectedCameraID: String?
+
     @ObservationIgnored
     private let room = LiveKit.Room()
     @ObservationIgnored
@@ -61,6 +68,17 @@ public final class CallViewModel: CallViewModelProtocol {
     /// "more Update Constraints in Window passes than there are views".
     @ObservationIgnored
     private var videoViewCache: [String: (trackObjectID: ObjectIdentifier, view: AnyView)] = [:]
+
+    // MARK: - Camera selection
+
+    /// Maps `CameraDevice.id` (`AVCaptureDevice.uniqueID`) back to the SDK
+    /// device so `selectCamera` can resolve a picked entry. `AVCaptureDevice`
+    /// never leaves RelayKit.
+    @ObservationIgnored
+    private var cameraDevicesByID: [String: AVCaptureDevice] = [:]
+    /// UserDefaults key for the last-used camera, preferred on the next call.
+    @ObservationIgnored
+    private let selectedCameraDefaultsKey = "selectedCameraUniqueID"
 
     // MARK: - E2EE State
     //
@@ -467,8 +485,18 @@ public final class CallViewModel: CallViewModelProtocol {
             // Key is now installed locally and (best-effort) distributed to
             // any existing call participants. Safe to publish media.
             connectingPhase = "Starting camera & microphone…"
+            await refreshCameras()
+            // Prefer the last-used camera if it's still present; otherwise let
+            // LiveKit pick the system default.
+            if let saved = UserDefaults.standard.string(forKey: selectedCameraDefaultsKey),
+               cameraDevicesByID[saved] != nil {
+                selectedCameraID = saved
+            }
             try await room.localParticipant.setMicrophone(enabled: true)
-            try await room.localParticipant.setCamera(enabled: true)
+            try await room.localParticipant.setCamera(enabled: true, captureOptions: selectedCameraCaptureOptions())
+            // Reflect whichever device actually started so the picker checkmark
+            // is correct even when we defaulted.
+            if selectedCameraID == nil { selectedCameraID = currentCameraDeviceID() }
 
             isLocalCameraEnabled = true
             isLocalMicrophoneEnabled = true
@@ -628,12 +656,86 @@ public final class CallViewModel: CallViewModelProtocol {
 
     public func toggleCamera() async throws {
         let enabled = !isLocalCameraEnabled
-        try await room.localParticipant.setCamera(enabled: enabled)
+        try await room.localParticipant.setCamera(
+            enabled: enabled,
+            captureOptions: enabled ? selectedCameraCaptureOptions() : nil
+        )
         isLocalCameraEnabled = enabled
+        if enabled, selectedCameraID == nil { selectedCameraID = currentCameraDeviceID() }
         if let localID = localParticipantID {
             videoViewCache.removeValue(forKey: localID)
         }
         videoTrackRevision += 1
+    }
+
+    public func refreshCameras() async {
+        let devices = (try? await CameraCapturer.captureDevices()) ?? []
+        var byID: [String: AVCaptureDevice] = [:]
+        var list: [CameraDevice] = []
+        for device in devices {
+            byID[device.uniqueID] = device
+            list.append(CameraDevice(
+                id: device.uniqueID,
+                name: device.localizedName,
+                kind: Self.cameraKind(for: device)
+            ))
+        }
+        cameraDevicesByID = byID
+        availableCameras = list
+    }
+
+    public func selectCamera(_ device: CameraDevice) async throws {
+        guard let avDevice = cameraDevicesByID[device.id] else { return }
+        selectedCameraID = device.id
+        UserDefaults.standard.set(device.id, forKey: selectedCameraDefaultsKey)
+        // Switch the device on the capturer whenever one exists — even when the
+        // camera is muted/off, LiveKit keeps the capturer around, so we must
+        // retarget it now rather than relying on a later setCamera(enabled:)
+        // (which unmutes the existing track and would keep the old device,
+        // leaving the self-view out of sync with the menu). If no capturer
+        // exists (track fully unpublished), the stored selection is applied on
+        // the next enable via selectedCameraCaptureOptions().
+        if let publication = room.localParticipant.localVideoTracks.first(where: { $0.source == .camera }),
+           let track = publication.track as? LocalVideoTrack,
+           let capturer = track.capturer as? CameraCapturer {
+            let newOptions = capturer.options.copyWith(device: .value(avDevice as AVCaptureDevice?))
+            _ = try await capturer.set(options: newOptions)
+            if let localID = localParticipantID {
+                videoViewCache.removeValue(forKey: localID)
+            }
+            videoTrackRevision += 1
+        }
+        activityLog?.log(
+            category: .call, severity: .info, source: "CallViewModel",
+            summary: "Camera input selected",
+            detail: "Camera: \(device.name) [\(device.kind)]",
+            roomId: roomID
+        )
+    }
+
+    /// Capture options pinned to the selected device, or `nil` to let LiveKit
+    /// use the system default.
+    private func selectedCameraCaptureOptions() -> CameraCaptureOptions? {
+        guard let id = selectedCameraID, let device = cameraDevicesByID[id] else { return nil }
+        return CameraCaptureOptions(device: device)
+    }
+
+    /// The `uniqueID` of the camera the local video track is currently
+    /// capturing from, if any.
+    private func currentCameraDeviceID() -> String? {
+        guard let publication = room.localParticipant.localVideoTracks.first(where: { $0.source == .camera }),
+              let track = publication.track as? LocalVideoTrack,
+              let capturer = track.capturer as? CameraCapturer else { return nil }
+        return capturer.device?.uniqueID
+    }
+
+    private static func cameraKind(for device: AVCaptureDevice) -> CameraDevice.Kind {
+        switch device.deviceType {
+        case .builtInWideAngleCamera: return .builtIn
+        case .continuityCamera: return .continuity
+        case .external: return .external
+        default: return .unknown
+        }
     }
 
     public func toggleMicrophone() async throws {


### PR DESCRIPTION
## Summary

Lets users choose which camera and microphone feed a call — built-in,
external/USB, or an **iPhone via Continuity Camera** for video — like FaceTime.
Previously the call always used whatever devices LiveKit picked by default.

## How it works

Both pickers share one pattern (protocol → `CallViewModel` → `CallView` →
preview) and surface as a **split control** on the call pill: the existing
on/off toggle plus a disclosure menu of devices with a checkmark on the active
one, shown only when more than one device exists. Menus refresh their list each
time they open, so a device connected mid-call appears.

- **`CameraDevice` / `AudioInputDevice`** value types (in `RelayInterface`,
  `id`/`name`[/`kind`]) let the UI list and pick devices without depending on
  AVFoundation or the audio SDK; `CallViewModel` maps them to/from the SDK
  types by id.
- **Camera** — enumerated via `CameraCapturer.captureDevices()` (surfaces
  `.continuityCamera`/`.external` on macOS 14+). Selecting retargets the live
  capturer (`capturer.set(options: options.copyWith(device:))`) whether the
  camera is on or muted, so the self-view never drifts from the menu.
- **Microphone** — backed by LiveKit's `AudioManager` (`inputDevices` /
  `inputDevice`). Same-named CoreAudio duplicates (e.g. AirPods register
  several) are collapsed to one entry. The switch runs off the main actor so
  the UI stays responsive while the audio engine reconfigures.
- **Persistence** — the last-used camera and microphone are remembered (by
  device id) in `UserDefaults` and preferred on the next call when still
  present; a stale id validates against the current device list and falls back
  to the system default.

## Known limitation (audio)

Switching microphones mid-call churns LiveKit's AVAudioEngine audio device
module (voice-processing graph rebuild) — selection works but isn't yet
seamless, and there's a brief audio glitch during the switch. This is an
upstream SDK/CoreAudio robustness area; tracked for a follow-up (candidate: the
`.platformDefault` ADM, or a newer SDK). Camera switching is unaffected.

## Requirements

No new permission — reuses the existing camera/microphone authorizations.

## Testing

- Camera: source menu lists built-in plus external and **iPhone (Continuity)**,
  checkmark on active; selecting switches local + remote video live; switching
  while the camera is off keeps the choice; a new call opens on the last-used
  camera.
- Microphone: source menu lists inputs (AirPods shown once, not duplicated);
  selecting switches the input without freezing the UI; last-used mic preferred
  on the next call.
- SwiftUI preview of `CallView` renders both split controls with mock devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)