### PR TITLE
Make the room pill a bit more dynamic

### DIFF
--- a/Relay/Views/MainView.swift
+++ b/Relay/Views/MainView.swift
@@ -750,7 +750,7 @@ private struct ToolbarRoomLabel: View {
                     .fontWeight(.semibold)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(minWidth: 100, maxWidth: 280)
+                    .frame(maxWidth: 280)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
 

--- a/Relay/Views/MainView.swift
+++ b/Relay/Views/MainView.swift
@@ -355,7 +355,7 @@ struct MainView: View { // swiftlint:disable:this type_body_length
                 inviteToolbarCapsule(for: room)
             }
         } else if let selectedRoomId, currentRoom != nil {
-            ToolbarItem(placement: .secondaryAction) {
+            ToolbarItem(placement: .principal) {
                 toolbarTitleCapsule
             }
 
@@ -748,8 +748,9 @@ private struct ToolbarRoomLabel: View {
                 Text(room.name)
                     .font(.title3)
                     .fontWeight(.semibold)
+                    .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(maxWidth: 100)
+                    .frame(minWidth: 100, maxWidth: 280)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
 


### PR DESCRIPTION
Make the room pill a principal toolbar item and set the minimum width to the current maximum width, and increasing the maximum width to 280pt.

### Before
<img width="1497" height="1129" alt="Screenshot 2026-07-27 at 21 20 26" src="https://github.com/user-attachments/assets/1e2cfc04-33a6-433f-99a6-f8f2ddb014aa" />

### After
<img width="1497" height="1129" alt="Screenshot 2026-07-27 at 21 21 12" src="https://github.com/user-attachments/assets/6760865b-4d59-4dc1-b47e-a4bda2c98c56" />

### With less width
<img width="446" height="573" alt="Screenshot 2026-07-27 at 21 21 35" src="https://github.com/user-attachments/assets/ac53b34c-6792-408e-95c7-dab8df82f7ab" />
