### PR TITLE
Possibly fix too many open file descriptors

### DIFF
--- a/RelayKit/Client/ClientBuilderProxy.swift
+++ b/RelayKit/Client/ClientBuilderProxy.swift
@@ -28,7 +28,7 @@ import Foundation
 /// ```swift
 /// let client = try await ClientBuilderProxy()
 ///     .homeserverUrl("https://matrix.org")
-///     .sessionPaths(dataPath: dataDir, cachePath: cacheDir)
+///     .sessionPaths(dataPath: dataDir, cachePath: cacheDir, poolMaxSize: 4)
 ///     .build()
 /// ```
 ///
@@ -38,7 +38,7 @@ import Foundation
 /// - ``homeserverUrl(_:)``
 /// - ``serverName(_:)``
 /// - ``serverNameOrHomeserverUrl(_:)``
-/// - ``sessionPaths(dataPath:cachePath:)``
+/// - ``sessionPaths(dataPath:cachePath:poolMaxSize:)``
 /// - ``username(_:)``
 ///
 /// ### Building
@@ -86,10 +86,13 @@ public final class ClientBuilderProxy: @unchecked Sendable {
     /// - Parameters:
     ///   - dataPath: The path for persistent data.
     ///   - cachePath: The path for cache data.
+    ///   - poolMaxSize: The maximum number of SQLite connections per store.
     /// - Returns: This builder for chaining.
     @discardableResult
-    public func sessionPaths(dataPath: String, cachePath: String) -> ClientBuilderProxy {
-        builder = builder.sessionPaths(dataPath: dataPath, cachePath: cachePath)
+    public func sessionPaths(dataPath: String, cachePath: String, poolMaxSize: UInt32) -> ClientBuilderProxy {
+        let store = SqliteStoreBuilder(dataPath: dataPath, cachePath: cachePath)
+            .poolMaxSize(poolMaxSize: poolMaxSize)
+        builder = builder.sqliteStore(config: store)
         return self
     }
 

--- a/RelayKit/Services/AuthenticationService.swift
+++ b/RelayKit/Services/AuthenticationService.swift
@@ -137,7 +137,10 @@ final class AuthenticationService {
         return ClientBuilderProxy()
             .sessionPaths(
                 dataPath: Self.dataDirectory.path,
-                cachePath: Self.cacheDirectory.path
+                cachePath: Self.cacheDirectory.path,
+                // The SDK default is four connections per physical CPU for each store,
+                // which can exhaust macOS file descriptors on high-core-count systems.
+                poolMaxSize: 4
             )
             .slidingSyncVersionBuilder(.discoverNative)
             .autoEnableCrossSigning(true)


### PR DESCRIPTION
On my machine, I had troubles starting the application and sometimes other issues, that were not immediately noticable. Looking in the logs, the application crashed because of too many open file descriptors, which primarly were open by matrix-rust-sdk, opening a pool of max(2, 4 * core-count) per sqlite file.

Maintaining now a default of 4 connections (for writing and reading) by using SqliteStoreBuilder directly, this should hopefully improve the performance. This is sadly not really benchmarkable for me in the current state, but evaluating with my same account, I could not notice any regressions and would hope the same for everybody else!

This should be the final solution to #83