### PR TITLE
Update build settings to let contributors build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ Relay is a native macOS app built with SwiftUI and Xcode.
 
 - macOS 26.0 (Tahoe) or later
 - Xcode 26.0 or later
+- An Apple ID added to Xcode (**Settings > Accounts**). A free account is
+  enough -- no paid Apple Developer Program membership required. This is
+  needed because Relay's app sandbox and app group entitlements require a
+  real development certificate; there's no way to build and run the app
+  without signing in to at least a free "Personal Team".
 
 ### Steps
 
@@ -39,7 +44,8 @@ Relay is a native macOS app built with SwiftUI and Xcode.
      try to register the bundle identifier to your account and they're 
      globally unique.
    - **`DEVELOPMENT_TEAM`** -- Your Apple Developer Team ID. Find it in
-     Xcode under **Settings > Accounts**, or at
+     Xcode under **Settings > Accounts** (select your Apple ID, then your
+     team -- a free "Personal Team" works fine), or at
      <https://developer.apple.com/account>.
    - **`GIPHY_API_KEY`** -- Required for GIF search functionality. Create
      one at <https://developers.giphy.com/dashboard/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ Relay is a native macOS app built with SwiftUI and Xcode.
 
    Open `Secrets.xcconfig` and fill in your values:
 
+   - **`BUNDLE_PREFIX`** -- a custom prefix for the app bundle. Xcode *will*
+     try to register the bundle identifier to your account and they're 
+     globally unique.
    - **`DEVELOPMENT_TEAM`** -- Your Apple Developer Team ID. Find it in
      Xcode under **Settings > Accounts**, or at
      <https://developer.apple.com/account>.

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -491,12 +491,13 @@
 /* Begin XCBuildConfiguration section */
 		3B11E08E2F9A3F600051F7B3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayTests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -509,12 +510,13 @@
 		};
 		3B11E08F2F9A3F600051F7B3 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayTests;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -824,7 +826,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayKit;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayKit";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -855,7 +857,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayKit;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayKit";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -99,6 +99,13 @@
 			);
 			target = 3B4AFD882F638A35001F0EA1 /* Relay */;
 		};
+		3BRK00232FC00023001F0EA1 /* Exceptions for "RelayKit" folder in "RelayKit" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 3BRK00102FC00010001F0EA1 /* RelayKit */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -126,6 +133,9 @@
 		};
 		3BRK00112FC00011001F0EA1 /* RelayKit */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				3BRK00232FC00023001F0EA1 /* Exceptions for "RelayKit" folder in "RelayKit" target */,
+			);
 			path = RelayKit;
 			sourceTree = "<group>";
 		};
@@ -818,6 +828,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RelayKit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -849,6 +860,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RelayKit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -495,7 +495,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 46UKXDYHHC;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -514,7 +513,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 46UKXDYHHC;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.RelayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -546,7 +544,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.Relay.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).Relay.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -576,7 +574,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.Relay.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).Relay.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -625,7 +623,6 @@
 				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 46UKXDYHHC;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -694,7 +691,6 @@
 				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 46UKXDYHHC;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -750,7 +746,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.Relay;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).Relay";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -795,7 +791,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.subpop.Relay;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).Relay";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -504,7 +504,6 @@
 			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayTests";
@@ -523,7 +522,6 @@
 			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_PREFIX).RelayTests";
@@ -539,10 +537,9 @@
 		};
 		3B3B82C62FC69A9F008DCEDC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RelayShareExtension/RelayShareExtension.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -569,10 +566,9 @@
 		};
 		3B3B82C72FC69A9F008DCEDC /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = RelayShareExtension/RelayShareExtension.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -732,8 +728,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
@@ -777,8 +771,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
@@ -819,8 +811,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -851,8 +841,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3BSEC0012FEF0001001F0EA1 /* Secrets.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/Relay/Info.plist
+++ b/Relay/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>RelayAppGroupIdentifier</key>
+	<string>group.$(DEVELOPMENT_TEAM).$(BUNDLE_PREFIX).Relay</string>
 	<key>CFBundleHelpBookFolder</key>
 	<string>Relay.help</string>
 	<key>CFBundleHelpBookName</key>

--- a/Relay/Relay.entitlements
+++ b/Relay/Relay.entitlements
@@ -4,17 +4,17 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.$(DEVELOPMENT_TEAM).$(BUNDLE_PREFIX).Relay</string>
+	</array>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.46UKXDYHHC.app.subpop.Relay</string>
-	</array>
-	<key>com.apple.security.device.camera</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
 	<true/>
 </dict>
 </plist>

--- a/RelayKit/Core/AppGroup.swift
+++ b/RelayKit/Core/AppGroup.swift
@@ -14,8 +14,15 @@
 
 import Foundation
 
+private final class BundleAnchor {}
+
 public enum AppGroup: Sendable {
-    nonisolated public static let identifier = "group.46UKXDYHHC.app.subpop.Relay"
+    nonisolated public static let identifier: String = {
+        guard let identifier = Bundle(for: BundleAnchor.self).object(forInfoDictionaryKey: "RelayAppGroupIdentifier") as? String else {
+            fatalError("RelayAppGroupIdentifier missing from RelayKit's Info.plist")
+        }
+        return identifier
+    }()
 
     nonisolated public static var containerURL: URL? {
         FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)

--- a/RelayKit/Info.plist
+++ b/RelayKit/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>RelayAppGroupIdentifier</key>
+	<string>group.$(DEVELOPMENT_TEAM).$(BUNDLE_PREFIX).Relay</string>
+</dict>
+</plist>

--- a/RelayShareExtension/AppGroup.swift
+++ b/RelayShareExtension/AppGroup.swift
@@ -15,7 +15,12 @@
 import Foundation
 
 enum AppGroup {
-    static let identifier = "group.46UKXDYHHC.app.subpop.Relay"
+    static let identifier: String = {
+        guard let identifier = Bundle.main.object(forInfoDictionaryKey: "RelayAppGroupIdentifier") as? String else {
+            fatalError("RelayAppGroupIdentifier missing from RelayShareExtension's Info.plist")
+        }
+        return identifier
+    }()
 
     static var containerURL: URL? {
         FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)

--- a/RelayShareExtension/Info.plist
+++ b/RelayShareExtension/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>RelayAppGroupIdentifier</key>
+	<string>group.$(DEVELOPMENT_TEAM).$(BUNDLE_PREFIX).Relay</string>
+	<key>RelayMainAppBundleIdentifier</key>
+	<string>$(BUNDLE_PREFIX).Relay</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/RelayShareExtension/RelayShareExtension.entitlements
+++ b/RelayShareExtension/RelayShareExtension.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.46UKXDYHHC.app.subpop.Relay</string>
+		<string>group.$(DEVELOPMENT_TEAM).$(BUNDLE_PREFIX).Relay</string>
 	</array>
 </dict>
 </plist>

--- a/RelayShareExtension/ShareViewController.swift
+++ b/RelayShareExtension/ShareViewController.swift
@@ -91,7 +91,9 @@ class ShareViewController: NSViewController {
         // bundle ID to avoid the URL-based dispatch that creates a new window.
         writeLatestShareId(share.id)
 
-        let bundleId = "app.subpop.Relay"
+        guard let bundleId = Bundle.main.object(forInfoDictionaryKey: "RelayMainAppBundleIdentifier") as? String else {
+            fatalError("RelayMainAppBundleIdentifier missing from RelayShareExtension's Info.plist")
+        }
         if let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
             app.activate()
         } else if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {

--- a/Secrets.xcconfig.example
+++ b/Secrets.xcconfig.example
@@ -3,11 +3,15 @@
 // Copy this file to Secrets.xcconfig and fill in your values.
 // Secrets.xcconfig is gitignored and will not be committed.
 //
+// BUNDLE_PREFIX: A valid prefix for the bundle identifier (default would be app.subpop)
+// Xcode tries to register the bundle identifier to your account and this are globally unique.
+//
 // DEVELOPMENT_TEAM: Your Apple Developer Team ID. You can find it in Xcode
 // under Settings > Accounts, or at https://developer.apple.com/account
 //
 // GIPHY_API_KEY: Required for GIF search. Obtain one at:
 // https://developers.giphy.com/dashboard/
 
+BUNDLE_PREFIX = your_bundle_prefix
 DEVELOPMENT_TEAM = your_team_id_here
 GIPHY_API_KEY = your_giphy_api_key_here

--- a/Secrets.xcconfig.example
+++ b/Secrets.xcconfig.example
@@ -7,11 +7,22 @@
 // Xcode tries to register the bundle identifier to your account and this are globally unique.
 //
 // DEVELOPMENT_TEAM: Your Apple Developer Team ID. You can find it in Xcode
-// under Settings > Accounts, or at https://developer.apple.com/account
+// under Settings > Accounts, or at https://developer.apple.com/account. A
+// free "Personal Team" is fine -- no paid Apple Developer Program membership
+// required. Relay's app sandbox and app group entitlements require a real
+// development certificate, so some Apple ID signed in to Xcode is required;
+// there's no way to build without one.
 //
 // GIPHY_API_KEY: Required for GIF search. Obtain one at:
 // https://developers.giphy.com/dashboard/
+//
+// CODE_SIGN_STYLE / CODE_SIGN_IDENTITY: How the app is signed. The defaults
+// below (Automatic + Apple Development) work with any team, free or paid.
+// You shouldn't need to change these.
 
 BUNDLE_PREFIX = your_bundle_prefix
 DEVELOPMENT_TEAM = your_team_id_here
 GIPHY_API_KEY = your_giphy_api_key_here
+
+CODE_SIGN_STYLE = Automatic
+CODE_SIGN_IDENTITY = Apple Development


### PR DESCRIPTION
Xcode *will* error out with the defaults originally in the files. I made these changes and Xcode was able to successfully build Relay.

I have not tested a scenario where the person building the app does not have a developer account.